### PR TITLE
Listen to maintenance events for interfaces

### DIFF
--- a/main.py
+++ b/main.py
@@ -897,6 +897,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Deal with the start of UNIs maintenance."""
         maintenance_unis = event.content['unis']
         for maintenance_uni in maintenance_unis:
+            maintenance_uni.interface.previous_state =\
+                maintenance_uni.interface.is_enabled()
             maintenance_uni.interface.disable()
             if maintenance_uni.interface.is_active():
                 self.handle_link_down(maintenance_uni.interface)
@@ -907,6 +909,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Deal with the end of links maintenance."""
         maintenance_unis = event.content['unis']
         for maintenance_uni in maintenance_unis:
-            maintenance_uni.interface.enable()
+            if (
+                hasattr(maintenance_uni.interface, 'previous_state') and
+                maintenance_uni.interface.previous_state
+            ):
+                maintenance_uni.interface.enable()
             self.handle_link_up(maintenance_uni.interface)
         self.notify_topology_update()

--- a/main.py
+++ b/main.py
@@ -854,7 +854,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     @listen_to('kytos/maintenance.start_link')
     def handle_link_maintenance_start(self, event):
-        """Deals with the start of links maintenance."""
+        """Deal with the start of links maintenance."""
         notify_links = []
         maintenance_links = event.content['links']
         for maintenance_link in maintenance_links:
@@ -874,7 +874,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     @listen_to('kytos/maintenance.end_link')
     def handle_link_maintenance_end(self, event):
-        """Deals with the end of links maintenance."""
+        """Deal with the end of links maintenance."""
         notify_links = []
         maintenance_links = event.content['links']
         for maintenance_link in maintenance_links:
@@ -891,3 +891,22 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.endpoint_a.enable()
             link.endpoint_b.enable()
             self.notify_link_status_change(link, reason='maintenance')
+
+    @listen_to('kytos/maintenance.start_uni')
+    def handle_uni_maintenance_start(self, event):
+        """Deal with the start of UNIs maintenance."""
+        maintenance_unis = event.content['unis']
+        for maintenance_uni in maintenance_unis:
+            maintenance_uni.interface.disable()
+            if maintenance_uni.interface.is_active():
+                self.handle_link_down(maintenance_uni.interface)
+        self.notify_topology_update()
+
+    @listen_to('kytos/maintenance.end_uni')
+    def handle_uni_maintenance_end(self, event):
+        """Deal with the end of links maintenance."""
+        maintenance_unis = event.content['unis']
+        for maintenance_uni in maintenance_unis:
+            maintenance_uni.interface.enable()
+            self.handle_link_up(maintenance_uni.interface)
+        self.notify_topology_update()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -42,6 +42,8 @@ class TestMain(TestCase):
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
                            'kytos/storehouse.loaded',
+                           'kytos/maintenance.start_uni',
+                           'kytos/maintenance.end_uni',
                            '.*.network_status.updated',
                            '.*.interface.is.nni',
                            '.*.connection.lost',
@@ -1317,4 +1319,42 @@ class TestMain(TestCase):
         event = MagicMock()
         event.content = content
         self.napp.handle_switch_maintenance_end(event)
+        self.assertEqual(handle_link_up_mock.call_count, 5)
+
+    @patch('napps.kytos.topology.main.Main.handle_link_down')
+    def test_handle_uni_maintenance_start(self, handle_link_down_mock):
+        """Test handle_uni_maintenance_start."""
+        uni1 = MagicMock()
+        uni1.interface.is_active.return_value = True
+        uni2 = MagicMock()
+        uni2.interface.is_active.return_value = False
+        uni3 = MagicMock()
+        uni3.interface.is_active.return_value = True
+        uni4 = MagicMock()
+        uni4.interface.is_active.return_value = False
+        uni5 = MagicMock()
+        uni5.interface.is_active.return_value = True
+        content = {'unis': [uni1, uni2, uni3, uni4, uni5]}
+        event = MagicMock()
+        event.content = content
+        self.napp.handle_uni_maintenance_start(event)
+        self.assertEqual(handle_link_down_mock.call_count, 3)
+
+    @patch('napps.kytos.topology.main.Main.handle_link_up')
+    def test_handle_uni_maintenance_end(self, handle_link_up_mock):
+        """Test handle_uni_maintenance_end."""
+        uni1 = MagicMock()
+        uni1.interface.is_active.return_value = True
+        uni2 = MagicMock()
+        uni2.interface.is_active.return_value = False
+        uni3 = MagicMock()
+        uni3.interface.is_active.return_value = True
+        uni4 = MagicMock()
+        uni4.interface.is_active.return_value = False
+        uni5 = MagicMock()
+        uni5.interface.is_active.return_value = True
+        content = {'unis': [uni1, uni2, uni3, uni4, uni5]}
+        event = MagicMock()
+        event.content = content
+        self.napp.handle_uni_maintenance_end(event)
         self.assertEqual(handle_link_up_mock.call_count, 5)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1345,16 +1345,23 @@ class TestMain(TestCase):
         """Test handle_uni_maintenance_end."""
         uni1 = MagicMock()
         uni1.interface.is_active.return_value = True
+        uni1.interface.previous_state = True
         uni2 = MagicMock()
         uni2.interface.is_active.return_value = False
+        uni2.interface.previous_state = True
         uni3 = MagicMock()
         uni3.interface.is_active.return_value = True
+        uni3.interface.previous_state = True
         uni4 = MagicMock()
         uni4.interface.is_active.return_value = False
+        uni4.interface.previous_state = False
         uni5 = MagicMock()
         uni5.interface.is_active.return_value = True
+        uni5.interface.previous_state = True
         content = {'unis': [uni1, uni2, uni3, uni4, uni5]}
         event = MagicMock()
         event.content = content
         self.napp.handle_uni_maintenance_end(event)
         self.assertEqual(handle_link_up_mock.call_count, 5)
+        uni5.interface.enable.assert_called_once()
+        uni4.interface.enable.assert_not_called()


### PR DESCRIPTION
Fixes #8 

Description of the change
=================

Topology was only listening to maintenance events for switches or links. 
This PR implements listeners for maintenances involving interfaces, generating corresponding
link up/down events.

Verification process
=============

Unit tests for this change were implemented and all the other tests passed.