### PR TITLE
Fix PR 18 by adding mandatory argument for KytosEvent listening method

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
         self._lock = Lock()
 
+    # pylint: disable=unused-argument,arguments-differ
     @listen_to('kytos/storehouse.loaded')
     def execute(self, event=None):
         """Execute once when the napp is running."""


### PR DESCRIPTION
Fixes #22 

PR #18 added a listening decorator to `execute()` method, which then can be called by Kytos startup process (without arguments) or by KytosEvent system (which provides the event argument). This PR will fix the method definition to match both calls.