### PR TITLE
Decouple execution of administrative state persistency from topology itself and other napps via listen to events

### DIFF
--- a/main.py
+++ b/main.py
@@ -687,19 +687,21 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     #    if settings.DISPLAY_FULL_DUPLEX_LINKS:
     #        self.topology.add_link(host.id, interface.id)
 
-    # pylint: disable=unused-argument
     @listen_to('.*.network_status.updated')
-    def save_status_on_storehouse(self, event=None):
+    def handle_network_status_updated(self, event):
+        """Handle *.network_status.updated events, specially from of_lldp."""
+        content = event.content
+        log.info(f"Storing the administrative state of the"
+                 f" {content['attribute']} attribute to"
+                 f" {content['state']} in the interfaces"
+                 f" {content['interface_ids']}")
+        self.save_status_on_storehouse()
+
+    def save_status_on_storehouse(self):
         """Save the network administrative status using storehouse."""
         with self._lock:
             status = self._get_switches_dict()
             status['id'] = 'network_status'
-            if event:
-                content = event.content
-                log.info(f"Storing the administrative state of the"
-                         f" {content['attribute']} attribute to"
-                         f" {content['state']} in the interfaces"
-                         f" {content['interface_ids']}")
             status.update(self._get_links_dict())
             self.storehouse.save_status(status)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -906,6 +906,17 @@ class TestMain(TestCase):
         response = api.post(url)
         self.assertEqual(response.status_code, 404, response.data)
 
+    @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
+    def test_handle_network_status_updated(self, mock_save_status):
+        """Test handle_link_maintenance_start."""
+        event = MagicMock()
+        event.name = 'kytos/of_lldp.network_status.updated'
+        event.content = {'attribute': 'LLDP',
+                         'state': 'enabled',
+                         'interface_ids': '00:00:00:00:00:00:00:01:1'}
+        self.napp.handle_network_status_updated(event)
+        mock_save_status.assert_called_once()
+
     def test_get_link_metadata(self):
         """Test get_link_metadata."""
         mock_link = MagicMock(Link)


### PR DESCRIPTION
Fixes #24 

### Description of the change

This PR will decouple the execution of the persistency method when called internally from topology (e.g., to enable/disable interfaces/switches/links) and when called from other Napps (e.g., to enable/disable LLDP interface's attribute from Kytos-ng/of_lldp Napp). By doing so, we can guarantee that the storehouse persistency event will be registered on Kytos buffers when returning the user request. So that, if the user shutdown Kytos right away after receiving a 200 status code, her/his request will still be persistent.

### Release notes

- Fix a condition where some user requests to change the administrative state of interfaces/links/switches can be lost if Kytos shut down right after the 200 response being received by the user.