### PR TITLE
[Fix] Simplify the process to persist metadata changes to avoid data loss

### DIFF
--- a/main.py
+++ b/main.py
@@ -791,6 +791,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             entity = 'link'
             entities = 'links'
 
+        self.save_metadata_on_store(obj, entities)
+
         name = f'kytos/topology.{entities}.metadata.{action}'
         event = KytosEvent(name=name, content={entity: obj,
                                                'metadata': obj.metadata})
@@ -808,26 +810,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         event = KytosEvent(name=name, content=event.content)
         self.controller.buffers.app.put(event)
 
-    @listen_to('kytos/topology.*.metadata.*')
-    def on_save_metadata_on_store(self, event):
-        """Send to storehouse the data updated."""
-        self.save_metadata_on_store(event)
-
-    def save_metadata_on_store(self, event):
+    def save_metadata_on_store(self, obj, entities):
         """Send to storehouse the data updated."""
         name = 'kytos.storehouse.update'
-        if 'switch' in event.content:
-            store = self.store_items.get('switches')
-            obj = event.content.get('switch')
-            namespace = 'kytos.topology.switches.metadata'
-        elif 'interface' in event.content:
-            store = self.store_items.get('interfaces')
-            obj = event.content.get('interface')
-            namespace = 'kytos.topology.interfaces.metadata'
-        elif 'link' in event.content:
-            store = self.store_items.get('links')
-            obj = event.content.get('link')
-            namespace = 'kytos.topology.links.metadata'
+        store = self.store_items.get(entities)
+        namespace = f'kytos.topology.{entities}.metadata'
 
         store.data[obj.id] = obj.metadata
         content = {'namespace': namespace,

--- a/main.py
+++ b/main.py
@@ -790,6 +790,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         elif isinstance(obj, Link):
             entity = 'link'
             entities = 'links'
+        else:
+            raise ValueError(
+                'Invalid object, supported: Switch, Interface, Link'
+            )
 
         self.save_metadata_on_store(obj, entities)
 

--- a/main.py
+++ b/main.py
@@ -296,7 +296,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             return jsonify("Switch not found"), 404
 
         switch.extend_metadata(metadata)
-        self.notify_metadata_changes(switch, 'added')
+        self.save_metadata_on_store(switch)
         return jsonify("Operation successful"), 201
 
     @rest('v3/switches/<dpid>/metadata/<key>', methods=['DELETE'])
@@ -308,7 +308,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             return jsonify("Switch not found"), 404
 
         switch.remove_metadata(key)
-        self.notify_metadata_changes(switch, 'removed')
+        self.save_metadata_on_store(switch)
         return jsonify("Operation successful"), 200
 
     # Interface related methods
@@ -417,7 +417,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             return jsonify("Interface not found"), 404
 
         interface.extend_metadata(metadata)
-        self.notify_metadata_changes(interface, 'added')
+        self.save_metadata_on_store(interface)
         return jsonify("Operation successful"), 201
 
     @rest('v3/interfaces/<interface_id>/metadata/<key>', methods=['DELETE'])
@@ -439,7 +439,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if interface.remove_metadata(key) is False:
             return jsonify("Metadata not found"), 404
 
-        self.notify_metadata_changes(interface, 'removed')
+        self.save_metadata_on_store(interface)
         return jsonify("Operation successful"), 200
 
     # Link related methods
@@ -497,7 +497,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             return jsonify("Link not found"), 404
 
         link.extend_metadata(metadata)
-        self.notify_metadata_changes(link, 'added')
+        self.save_metadata_on_store(link)
         return jsonify("Operation successful"), 201
 
     @rest('v3/links/<link_id>/metadata/<key>', methods=['DELETE'])
@@ -511,7 +511,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if link.remove_metadata(key) is False:
             return jsonify("Metadata not found"), 404
 
-        self.notify_metadata_changes(link, 'removed')
+        self.save_metadata_on_store(link)
         return jsonify("Operation successful"), 200
 
     @listen_to('.*.switch.(new|reconnected)')
@@ -779,24 +779,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             })
         self.controller.buffers.app.put(event)
 
-    def notify_metadata_changes(self, obj, action):
-        """Send an event to notify about metadata changes."""
-        if isinstance(obj, Switch):
-            entity = 'switch'
-            entities = 'switches'
-        elif isinstance(obj, Interface):
-            entity = 'interface'
-            entities = 'interfaces'
-        elif isinstance(obj, Link):
-            entity = 'link'
-            entities = 'links'
-
-        name = f'kytos/topology.{entities}.metadata.{action}'
-        event = KytosEvent(name=name, content={entity: obj,
-                                               'metadata': obj.metadata})
-        self.controller.buffers.app.put(event)
-        log.debug(f'Metadata from {obj.id} was {action}.')
-
     @listen_to('.*.switch.port.created')
     def on_notify_port_created(self, event):
         """Notify when a port is created."""
@@ -808,25 +790,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         event = KytosEvent(name=name, content=event.content)
         self.controller.buffers.app.put(event)
 
-    @listen_to('kytos/topology.*.metadata.*')
-    def on_save_metadata_on_store(self, event):
-        """Send to storehouse the data updated."""
-        self.save_metadata_on_store(event)
-
-    def save_metadata_on_store(self, event):
+    def save_metadata_on_store(self, obj):
         """Send to storehouse the data updated."""
         name = 'kytos.storehouse.update'
-        if 'switch' in event.content:
+        if isinstance(obj, Switch):
             store = self.store_items.get('switches')
-            obj = event.content.get('switch')
             namespace = 'kytos.topology.switches.metadata'
-        elif 'interface' in event.content:
+        elif isinstance(obj, Interface):
             store = self.store_items.get('interfaces')
-            obj = event.content.get('interface')
             namespace = 'kytos.topology.interfaces.metadata'
-        elif 'link' in event.content:
+        elif isinstance(obj, Link):
             store = self.store_items.get('links')
-            obj = event.content.get('link')
             namespace = 'kytos.topology.links.metadata'
 
         store.data[obj.id] = obj.metadata

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -158,8 +158,7 @@ class TestMain(TestCase):
                            '.*.switch.interface.link_up',
                            '.*.switch.(new|reconnected)',
                            '.*.switch.port.created',
-                           'kytos/storehouse.loaded',
-                           'kytos/topology.*.metadata.*']
+                           'kytos/storehouse.loaded']
         actual_events = self.napp.listeners()
         self.assertCountEqual(expected_events, actual_events)
 
@@ -244,11 +243,8 @@ class TestMain(TestCase):
 
     def test_save_metadata_on_store(self):
         """Test save metadata on store."""
-        event_name = 'kytos.storehouse.update'
         switch = get_switch_mock(0x04)
-        event = KytosEvent(name=event_name,
-                           content={'switch': switch})
-        self.napp.save_metadata_on_store(event)
+        self.napp.save_metadata_on_store(switch, 'switches')
         event_list_response = self.napp.controller.buffers.app.get()
         event_updated_response = self.napp.controller.buffers.app.get()
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -158,7 +158,8 @@ class TestMain(TestCase):
                            '.*.switch.interface.link_up',
                            '.*.switch.(new|reconnected)',
                            '.*.switch.port.created',
-                           'kytos/storehouse.loaded']
+                           'kytos/storehouse.loaded',
+                           'kytos/topology.*.metadata.*']
         actual_events = self.napp.listeners()
         self.assertCountEqual(expected_events, actual_events)
 
@@ -243,8 +244,11 @@ class TestMain(TestCase):
 
     def test_save_metadata_on_store(self):
         """Test save metadata on store."""
+        event_name = 'kytos.storehouse.update'
         switch = get_switch_mock(0x04)
-        self.napp.save_metadata_on_store(switch)
+        event = KytosEvent(name=event_name,
+                           content={'switch': switch})
+        self.napp.save_metadata_on_store(event)
         event_list_response = self.napp.controller.buffers.app.get()
         event_updated_response = self.napp.controller.buffers.app.get()
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -158,8 +158,7 @@ class TestMain(TestCase):
                            '.*.switch.interface.link_up',
                            '.*.switch.(new|reconnected)',
                            '.*.switch.port.created',
-                           'kytos/storehouse.loaded',
-                           'kytos/topology.*.metadata.*']
+                           'kytos/storehouse.loaded']
         actual_events = self.napp.listeners()
         self.assertCountEqual(expected_events, actual_events)
 
@@ -244,11 +243,8 @@ class TestMain(TestCase):
 
     def test_save_metadata_on_store(self):
         """Test save metadata on store."""
-        event_name = 'kytos.storehouse.update'
         switch = get_switch_mock(0x04)
-        event = KytosEvent(name=event_name,
-                           content={'switch': switch})
-        self.napp.save_metadata_on_store(event)
+        self.napp.save_metadata_on_store(switch)
         event_list_response = self.napp.controller.buffers.app.get()
         event_updated_response = self.napp.controller.buffers.app.get()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -50,7 +50,8 @@ class TestMain(TestCase):
                            '.*.switch.interface.link_down',
                            '.*.switch.interface.link_up',
                            '.*.switch.(new|reconnected)',
-                           '.*.switch.port.created']
+                           '.*.switch.port.created',
+                           'kytos/topology.*.metadata.*']
         actual_events = self.napp.listeners()
         self.assertCountEqual(expected_events, actual_events)
 
@@ -601,8 +602,8 @@ class TestMain(TestCase):
         response = api.get(url)
         self.assertEqual(response.status_code, 404, response.data)
 
-    @patch('napps.kytos.topology.main.Main.save_metadata_on_store')
-    def test_add_switch_metadata(self, mock_save_metadata):
+    @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
+    def test_add_switch_metadata(self, mock_metadata_changes):
         """Test add_switch_metadata."""
         dpid = "00:00:00:00:00:00:00:01"
         mock_switch = get_switch_mock(dpid)
@@ -614,7 +615,7 @@ class TestMain(TestCase):
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
         self.assertEqual(response.status_code, 201, response.data)
-        mock_save_metadata.assert_called()
+        mock_metadata_changes.assert_called()
 
         # fail case
         dpid = "00:00:00:00:00:00:00:02"
@@ -638,19 +639,18 @@ class TestMain(TestCase):
                             content_type='application/json')
         self.assertEqual(response.status_code, 415, response.data)
 
-    @patch('napps.kytos.topology.main.Main.save_metadata_on_store')
-    def test_delete_switch_metadata(self, mock_save_metadata):
+    @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
+    def test_delete_switch_metadata(self, mock_metadata_changes):
         """Test delete_switch_metadata."""
         dpid = "00:00:00:00:00:00:00:01"
         mock_switch = get_switch_mock(dpid)
         self.napp.controller.switches = {dpid: mock_switch}
-        self.napp.store_items = {'switches': MagicMock()}
         api = get_test_client(self.napp.controller, self.napp)
 
         key = "A"
         url = f'{self.server_name_url}/v3/switches/{dpid}/metadata/{key}'
         response = api.delete(url)
-        self.assertEqual(mock_save_metadata.call_count, 1)
+        mock_metadata_changes.assert_called()
         self.assertEqual(response.status_code, 200, response.data)
 
         # fail case
@@ -658,7 +658,7 @@ class TestMain(TestCase):
         dpid = "00:00:00:00:00:00:00:02"
         url = f'{self.server_name_url}/v3/switches/{dpid}/metadata/{key}'
         response = api.delete(url)
-        self.assertEqual(mock_save_metadata.call_count, 1)  # remains 1 call
+        mock_metadata_changes.assert_called()
         self.assertEqual(response.status_code, 404, response.data)
 
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
@@ -760,7 +760,6 @@ class TestMain(TestCase):
         mock_interface.metadata = {"metada": "A"}
         mock_switch.interfaces = {1: mock_interface}
         self.napp.controller.switches = {dpid: mock_switch}
-        self.napp.store_items = {'interfaces': MagicMock()}
         api = get_test_client(self.napp.controller, self.napp)
 
         url = f'{self.server_name_url}/v3/interfaces/{interface_id}/metadata'
@@ -779,8 +778,8 @@ class TestMain(TestCase):
         response = api.get(url)
         self.assertEqual(response.status_code, 404, response.data)
 
-    @patch('napps.kytos.topology.main.Main.save_metadata_on_store')
-    def test_add_interface_metadata(self, mock_save_metadata):
+    @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
+    def test_add_interface_metadata(self, mock_metadata_changes):
         """Test add_interface_metadata."""
         interface_id = '00:00:00:00:00:00:00:01:1'
         dpid = '00:00:00:00:00:00:00:01'
@@ -789,7 +788,6 @@ class TestMain(TestCase):
         mock_interface.metadata = {"metada": "A"}
         mock_switch.interfaces = {1: mock_interface}
         self.napp.controller.switches = {dpid: mock_switch}
-        self.napp.store_items = {'interfaces': MagicMock()}
         api = get_test_client(self.napp.controller, self.napp)
 
         url = f'{self.server_name_url}/v3/interfaces/{interface_id}/metadata'
@@ -797,7 +795,7 @@ class TestMain(TestCase):
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
         self.assertEqual(response.status_code, 201, response.data)
-        mock_save_metadata.assert_called()
+        mock_metadata_changes.assert_called()
 
         # fail case switch not found
         interface_id = '00:00:00:00:00:00:00:02:1'
@@ -838,7 +836,6 @@ class TestMain(TestCase):
         mock_interface.remove_metadata.side_effect = [True, False]
         mock_interface.metadata = {"metada": "A"}
         mock_switch.interfaces = {1: mock_interface}
-        self.napp.store_items = {'interfaces': MagicMock()}
         self.napp.controller.switches = {'00:00:00:00:00:00:00:01':
                                          mock_switch}
         api = get_test_client(self.napp.controller, self.napp)
@@ -920,7 +917,6 @@ class TestMain(TestCase):
         mock_link = MagicMock(Link)
         mock_link.metadata = "A"
         self.napp.links = {'1': mock_link}
-        self.napp.store_items = {'links': MagicMock()}
         msg_success = {"metadata": "A"}
         api = get_test_client(self.napp.controller, self.napp)
 
@@ -936,13 +932,12 @@ class TestMain(TestCase):
         response = api.get(url)
         self.assertEqual(response.status_code, 404, response.data)
 
-    @patch('napps.kytos.topology.main.Main.save_metadata_on_store')
-    def test_add_link_metadata(self, mock_save_metadata):
+    @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
+    def test_add_link_metadata(self, mock_metadata_changes):
         """Test add_link_metadata."""
         mock_link = MagicMock(Link)
         mock_link.metadata = "A"
         self.napp.links = {'1': mock_link}
-        self.napp.store_items = {'links': MagicMock()}
         payload = {"metadata": "A"}
         api = get_test_client(self.napp.controller, self.napp)
 
@@ -951,7 +946,7 @@ class TestMain(TestCase):
         response = api.post(url, data=json.dumps(payload),
                             content_type='application/json')
         self.assertEqual(response.status_code, 201, response.data)
-        mock_save_metadata.assert_called()
+        mock_metadata_changes.assert_called()
 
         # fail case
         link_id = 2
@@ -976,14 +971,13 @@ class TestMain(TestCase):
                             content_type='application/json')
         self.assertEqual(response.status_code, 415, response.data)
 
-    @patch('napps.kytos.topology.main.Main.save_metadata_on_store')
-    def test_delete_link_metadata(self, mock_save_metadata):
+    @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
+    def test_delete_link_metadata(self, mock_metadata_changes):
         """Test delete_link_metadata."""
         mock_link = MagicMock(Link)
         mock_link.metadata = "A"
         mock_link.remove_metadata.side_effect = [True, False]
         self.napp.links = {'1': mock_link}
-        self.napp.store_items = {'links': MagicMock()}
         api = get_test_client(self.napp.controller, self.napp)
 
         link_id = 1
@@ -991,7 +985,7 @@ class TestMain(TestCase):
         url = f'{self.server_name_url}/v3/links/{link_id}/metadata/{key}'
         response = api.delete(url)
         self.assertEqual(response.status_code, 200, response.data)
-        mock_save_metadata.assert_called()
+        mock_metadata_changes.assert_called()
 
         # fail case link not found
         link_id = 2
@@ -1171,6 +1165,20 @@ class TestMain(TestCase):
 
     @patch('napps.kytos.topology.main.KytosEvent')
     @patch('kytos.core.buffers.KytosEventBuffer.put')
+    @patch('napps.kytos.topology.main.isinstance')
+    def test_notify_metadata_changes(self, *args):
+        """Test notify metadata changes."""
+        (mock_isinstance, mock_buffers_put, mock_event) = args
+        mock_isinstance.return_value = True
+        mock_obj = MagicMock()
+        mock_action = create_autospec(Switch)
+        self.napp.notify_metadata_changes(mock_obj, mock_action)
+        mock_event.assert_called()
+        mock_isinstance.assert_called()
+        mock_buffers_put.assert_called()
+
+    @patch('napps.kytos.topology.main.KytosEvent')
+    @patch('kytos.core.buffers.KytosEventBuffer.put')
     def test_notify_port_created(self, *args):
         """Test notify port created."""
         (mock_buffers_put, mock_kytos_event) = args
@@ -1184,28 +1192,28 @@ class TestMain(TestCase):
     def test_save_metadata_on_store(self, *args):
         """Test test_save_metadata_on_store."""
         (mock_buffers_put, mock_kytos_event) = args
-        mock_store = MagicMock()
-        mock_switch = MagicMock(spec=Switch)
-        mock_switch.metadata = {}
-        mock_interface = MagicMock(spec=Interface)
-        mock_interface.metadata = {}
-        mock_link = MagicMock(spec=Link)
-        mock_link.metadata = {}
-        self.napp.store_items = {'switches': mock_store,
-                                 'interfaces': mock_store,
-                                 'links': mock_store}
+        mock_event = MagicMock()
+        mock_switch = MagicMock()
+        mock_interface = MagicMock()
+        mock_link = MagicMock()
+        self.napp.store_items = {'switches': mock_switch,
+                                 'interfaces': mock_interface,
+                                 'links': mock_link}
         # test switches
-        self.napp.save_metadata_on_store(mock_switch)
+        mock_event.content = {'switch': mock_switch}
+        self.napp.save_metadata_on_store(mock_event)
         mock_kytos_event.assert_called()
         mock_buffers_put.assert_called()
 
         # test interfaces
-        self.napp.save_metadata_on_store(mock_interface)
+        mock_event.content = {'interface': mock_interface}
+        self.napp.save_metadata_on_store(mock_event)
         mock_kytos_event.assert_called()
         mock_buffers_put.assert_called()
 
         # test link
-        self.napp.save_metadata_on_store(mock_link)
+        mock_event.content = {'link': mock_link}
+        self.napp.save_metadata_on_store(mock_event)
         mock_kytos_event.assert_called()
         mock_buffers_put.assert_called()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1178,6 +1178,8 @@ class TestMain(TestCase):
             self.assertEqual(mock_event.call_count, count+1)
             self.assertEqual(mock_buffers_put.call_count, count+1)
             count += 1
+        with self.assertRaises(ValueError):
+            self.napp.notify_metadata_changes(MagicMock(), 'added')
 
     @patch('napps.kytos.topology.main.KytosEvent')
     @patch('kytos.core.buffers.KytosEventBuffer.put')


### PR DESCRIPTION
Fixes #26 

Heads up: this PR was built on top of PR #28 (which has to land first)

### Description of the change

Due to the way kytos-ng/topology was doing the persistency of metadata changes/user-requests, it can leads to lost of information when kytos shutdown right after returning a success status code to the user (see Issue #26).

To fix this eventual undesired behavior, I've removed the KytosEvent `kytos/topology.{entities}.metadata.{action}` and added calls to `self.save_metadata_on_store()` directly. Indeed, the Kytos event `kytos/topology.{entities}.metadata.{action}` was just used internally by kytos-ng/topology and there was no benefit on keep using it.

Unit and integration tests were updated to reflect this new metadata persistency route.

End-to-end tests were run using this new approach and no failure was reported in a 400 repetitions test.


### Release notes

- Removed KytosEvent `kytos/topology.{entities}.metadata.{action}` used to persist metadata information, and using direct calls instead. The change improved reliability of metadata persistency.