### PR TITLE
Using a busy wait approach when saving topology status

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -5,8 +5,6 @@
 
 # Time (in seconds) to wait before setting a link as up
 LINK_UP_TIMER = 10
-# Time (in seconds) to wait retrieve box from storehouse
-BOX_RESTORE_TIMER = 0.1
 
 # Time (in seconds) to wait for a confirmation from storehouse
 # when retrieving or updating a box

--- a/settings.py
+++ b/settings.py
@@ -7,3 +7,10 @@
 LINK_UP_TIMER = 10
 # Time (in seconds) to wait retrieve box from storehouse
 BOX_RESTORE_TIMER = 0.1
+
+# Time (in seconds) to wait for a confirmation from storehouse
+# when retrieving or updating a box
+STOREHOUSE_TIMEOUT = 5.0
+
+# Time (in seconds) to sleep while waiting from storehouse (busy wait)
+STOREHOUSE_WAIT_INTERVAL = 0.05

--- a/storehouse.py
+++ b/storehouse.py
@@ -6,9 +6,6 @@ from kytos.core import log
 from kytos.core.events import KytosEvent
 from napps.kytos.topology import settings
 
-DEFAULT_BOX_RESTORE_TIMER = 0.1
-BOX_RESTORE_ATTEMPTS = 20
-
 
 class StoreHouse:
     """Class to handle storehouse."""
@@ -27,9 +24,6 @@ class StoreHouse:
         """Create a storehouse client instance."""
         self.controller = controller
         self.namespace = 'kytos.topology.status'
-        self.box_restore_timer = getattr(settings, 'BOX_RESTORE_TIMER',
-                                         DEFAULT_BOX_RESTORE_TIMER)
-
         if '_lock' not in self.__dict__:
             self._lock = threading.Lock()
         if 'box' not in self.__dict__:
@@ -40,9 +34,9 @@ class StoreHouse:
         """Return the persistence box data."""
         # Wait for box retrieve from storehouse
         i = 0
-        while not self.box and i < BOX_RESTORE_ATTEMPTS:
-            time.sleep(self.box_restore_timer)
-            i += 1
+        while not self.box and i < settings.STOREHOUSE_TIMEOUT:
+            time.sleep(settings.STOREHOUSE_WAIT_INTERVAL)
+            i += settings.STOREHOUSE_WAIT_INTERVAL
         if not self.box:
             error = 'Error retrieving persistence box from storehouse.'
             raise FileNotFoundError(error)


### PR DESCRIPTION
Fixes #31 

### Description of the change

The complete description of the problem was detailed in Issue #31. This PR will change the `topology.storehouse.save_status()` method to use a busy wait approach, in which the save status request will stay waiting for the storehouse update callback (up to a certain time) and can confirm the data was stored before returning to the user request.

The proper unit tests were created to validate the new approach.

New round of end-to-end tests were executed to validate if the new solution would actually fix the original issue. Out of 400 executions of the test [tests/test_e2e_05_topology.py::TestE2ETopology::test_030_disabling_switch_persistent](https://github.com/amlight/kytos-end-to-end-tests/blob/master/tests/test_e2e_05_topology.py#L130-L154), no fail was reported.
```
# cat run-test-topo
( for i in $(seq 1 100); do echo $i $(date); python -m pytest tests/test_e2e_05_topology.py::TestE2ETopology::test_030_disabling_switch_persistent; done; date ) | tee log-topo-e2e-$(date +%Y%m%d%H%M%S)
# for i in 1 2 3 4; do sh run-test-topo; done
# for LOG in log-topo-e2e-20211221*; do echo $LOG; echo passed $(grep -c ' passed ' $LOG) failed $(grep -c ' failed ' $LOG); done
log-topo-e2e-20211221021030
passed 100 failed 0
log-topo-e2e-20211221040320
passed 100 failed 0
log-topo-e2e-20211221055751
passed 100 failed 0
log-topo-e2e-20211221075235
passed 100 failed 0
```

In the future, the save approach can be augmented to also deploy a few retries and also apply some kind of rollback approach when the persistency didn't work as expected.

Minor adjustment was done at `topology.storehouse.get_data()` to use the same settings and approach for the busy wait adopted by `save_status()`.

Last but not least, `threading.Lock` mechanism was implemented to prevent race conditions at the `topology.storehouse.box` shared resource (Issue #31 provides examples where two consecutive calls could result in overlapping storehouse persistency).

### Release notes

- Added busy wait approach to validate that persistency was performed before returning to the user request. A timeout setting is available so that the operator can increase/decrease the maximum waiting time from the storehouse (STOREHOUSE_TIMEOUT, defaults to 5 seconds), as well as the waiting time before each check (STOREHOUSE_WAIT_INTERVAL , default to 50ms)
- Renamed setting BOX_RESTORE_TIMER to STOREHOUSE_WAIT_INTERVAL, which is used to retrieve data from the storehouse. Additionally, the retrieve process also have the maximum wait time configurable through STOREHOUSE_TIMEOUT