### PR TITLE
[Fix] `add_links` to only trigger a topology update if it's a new `Link`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,15 @@ Security
 ========
 
 
+[3.7.3] - 2021-12.21
+********************
+
+Changed
+=======
+- Changed ``add_links`` to only notify a topology update if a link has been created. 
+- Changed ``_get_link_or_create`` to also return whether or not a new link has been created.
+
+
 [3.7.2] - 2021-04-01
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp", "kytos/storehouse"],
   "license": "MIT",
   "tags": ["topology", "rest", "work-in-progress"],

--- a/main.py
+++ b/main.py
@@ -76,14 +76,19 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         return metadata
 
     def _get_link_or_create(self, endpoint_a, endpoint_b):
+        """Get an existing link or create a new one.
+
+        Returns:
+            Tuple(Link, bool): Link and a boolean whether it has been created.
+        """
         new_link = Link(endpoint_a, endpoint_b)
 
         for link in self.links.values():
             if new_link == link:
-                return link
+                return (link, False)
 
         self.links[new_link.id] = new_link
-        return new_link
+        return (new_link, True)
 
     def _get_switches_dict(self):
         """Return a dictionary with the known switches."""
@@ -136,7 +141,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             error = f'Fail to load endpoints for link {link_str}: {err}'
             raise RestoreError(error)
 
-        link = self._get_link_or_create(interface_a, interface_b)
+        link, _ = self._get_link_or_create(interface_a, interface_b)
 
         if link_att['enabled']:
             link.enable()
@@ -693,7 +698,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface_b = event.content['interface_b']
 
         try:
-            link = self._get_link_or_create(interface_a, interface_b)
+            link, created = self._get_link_or_create(interface_a, interface_b)
         except KytosLinkCreationError as err:
             log.error(f'Error creating link: {err}.')
             return
@@ -704,7 +709,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface_a.nni = True
         interface_b.nni = True
 
-        self.notify_topology_update()
+        if created:
+            self.notify_topology_update()
 
     # def add_host(self, event):
     #    """Update the topology with a new Host."""

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'topology'
-NAPP_VERSION = '3.7.2'
+NAPP_VERSION = '3.7.3'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -113,10 +113,15 @@ class TestMain(TestCase):
         mock_interface_a.id = dpid_a
         mock_interface_b.id = dpid_b
 
-        link = self.napp._get_link_or_create(mock_interface_a,
-                                             mock_interface_b)
+        link, created = self.napp._get_link_or_create(mock_interface_a,
+                                                      mock_interface_b)
+        self.assertTrue(created)
         self.assertEqual(link.endpoint_a.id, dpid_a)
         self.assertEqual(link.endpoint_b.id, dpid_b)
+
+        link, created = self.napp._get_link_or_create(mock_interface_a,
+                                                      mock_interface_b)
+        self.assertFalse(created)
 
     def test_get_link_from_interface(self):
         """Test _get_link_from_interface."""
@@ -484,7 +489,7 @@ class TestMain(TestCase):
         mock_link = get_link_mock(mock_interface_a, mock_interface_b)
         mock_link.id = link_id
         with patch('napps.kytos.topology.main.Main._get_link_or_create',
-                   return_value=mock_link):
+                   return_value=(mock_link, True)):
             # enable link
             link_attrs['enabled'] = True
             self.napp.links = {link_id: mock_link}
@@ -1110,6 +1115,7 @@ class TestMain(TestCase):
     def test_add_links(self, *args):
         """Test add_links."""
         (mock_notify_topology_update, mock_get_link_or_create) = args
+        mock_get_link_or_create.return_value = (MagicMock(), True)
         mock_event = MagicMock()
         self.napp.add_links(mock_event)
         mock_get_link_or_create.assert_called()


### PR DESCRIPTION
Fixes #21 

### Release notes

```
[3.7.3] - 2021-12.21
```

#### Changed

- Changed ``add_links`` to only notify a topology update if a link has been created. 
- Changed ``_get_link_or_create`` to also return whether or not a new link has been created.


### Before

Notice the periodic topology update events in the same frequency as `.*.interface.is.nni` are received:

```
kytos $> 2021-12-21 12:40:44,246 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_61) Topology graph updated.
2021-12-21 12:40:44,260 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_61) Topology graph updated.
2021-12-21 12:40:44,316 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_228) Topology graph updated.
2021-12-21 12:40:44,323 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_119) Topology graph updated.
2021-12-21 12:40:47,364 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_115) Topology graph updated.
2021-12-21 12:40:47,443 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_16) Topology graph updated.
2021-12-21 12:40:47,444 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_247) Topology graph updated.
2021-12-21 12:40:47,445 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_128) Topology graph updated.
2021-12-21 12:40:50,460 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_253) Topology graph updated.
2021-12-21 12:40:50,472 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_254) Topology graph updated.
2021-12-21 12:40:50,483 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_238) Topology graph updated.
2021-12-21 12:40:50,483 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_113) Topology graph updated.
2021-12-21 12:40:53,534 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_66) Topology graph updated.
2021-12-21 12:40:53,588 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_129) Topology graph updated.
2021-12-21 12:40:53,624 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_31) Topology graph updated.
2021-12-21 12:40:53,642 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_244) Topology graph updated.
2021-12-21 12:40:56,711 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_142) Topology graph updated.
2021-12-21 12:40:56,766 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_143) Topology graph updated.
2021-12-21 12:40:56,804 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_145) Topology graph updated.
2021-12-21 12:40:56,806 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_141) Topology graph updated.
2021-12-21 12:40:59,843 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_75) Topology graph updated.
2021-12-21 12:40:59,876 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_20) Topology graph updated.
2021-12-21 12:40:59,899 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_92) Topology graph updated.
2021-12-21 12:40:59,927 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_136) Topology graph updated.
2021-12-21 12:41:02,971 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_32) Topology graph updated.
2021-12-21 12:41:03,002 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_153) Topology graph updated.
2021-12-21 12:41:03,012 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_243) Topology graph updated.
2021-12-21 12:41:03,015 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_159) Topology graph updated.
2021-12-21 12:41:06,096 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_85) Topology graph updated.
2021-12-21 12:41:06,097 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_9) Topology graph updated.
2021-12-21 12:41:06,098 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_9) Topology graph updated.
2021-12-21 12:41:06,101 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_164) Topology graph updated.
2021-12-21 12:41:09,156 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_161) Topology graph updated.
2021-12-21 12:41:09,196 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_87) Topology graph updated.
2021-12-21 12:41:09,201 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_171) Topology graph updated.
2021-12-21 12:41:09,201 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_86) Topology graph updated.
2021-12-21 12:41:12,256 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_39) Topology graph updated.
2021-12-21 12:41:12,332 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_177) Topology graph updated.
2021-12-21 12:41:12,346 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_178) Topology graph updated.
2021-12-21 12:41:12,362 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_174) Topology graph updated.
kytos $>

```

### After

```
2021-12-21 12:58:53,647 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_53) Topology graph updated.
2021-12-21 12:58:53,652 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_58) Topology graph updated.
2021-12-21 12:58:53,664 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_63) Topology graph updated.
2021-12-21 12:58:53,685 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_31) Flow saved in kytos.flow.persistence.0fbe26be5bfc453882d118ba8315e473
2021-12-21 12:58:53,700 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_62) Flow saved in kytos.flow.persistence.0fbe26be5bfc453882d118ba8315e473
2021-12-21 12:58:53,754 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_60) Flow saved in kytos.flow.persistence.0fbe26be5bfc453882d118ba8315e473
2021-12-21 12:58:53,767 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_91) Topology graph updated.
2021-12-21 12:58:53,769 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_96) Topology graph updated.
2021-12-21 12:58:53,773 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_47) Topology graph updated.
2021-12-21 12:58:53,775 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_52) Topology graph updated.
2021-12-21 12:58:53,775 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_102) Topology graph updated.
2021-12-21 12:58:53,776 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_28) Topology graph updated.
2021-12-21 12:58:53,778 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_107) Topology graph updated.
2021-12-21 12:58:53,822 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_136) Flow saved in kytos.flow.persistence.0fbe26be5bfc453882d118ba8315e473
2021-12-21 12:58:53,871 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_58) Flow saved in kytos.flow.persistence.0fbe26be5bfc453882d118ba8315e473
2021-12-21 12:58:53,923 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_137) Flow saved in kytos.flow.persistence.0fbe26be5bfc453882d118ba8315e473
2021-12-21 12:58:55,720 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_144) Topology graph updated.
2021-12-21 12:58:55,746 - INFO [kytos.napps.kytos/pathfinder] (ThreadPoolExecutor-0_19) Topology graph updated.
kytos $>

```