### PR TITLE
[Fix] Fixed handle_link_down to deactivate interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,13 @@ Security
 ========
 
 
+[3.8.0] - 2021-12-22
+********************
+
+Changed
+=======
+- Fixed ``handle_link_down`` to also deactivate the interface
+
 [3.7.2] - 2021-04-01
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp", "kytos/storehouse"],
   "license": "MIT",
   "tags": ["topology", "rest", "work-in-progress"],

--- a/main.py
+++ b/main.py
@@ -680,13 +680,13 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def handle_link_down(self, interface):
         """Notify a link is down."""
-        interface.deactivate()
         link = self._get_link_from_interface(interface)
         if link and link.is_active():
             link.deactivate()
             link.update_metadata('last_status_change', time.time())
             self.notify_topology_update()
             self.notify_link_status_change(link, reason='link down')
+        interface.deactivate()
 
     @listen_to('.*.interface.is.nni')
     def on_add_links(self, event):

--- a/main.py
+++ b/main.py
@@ -581,7 +581,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """
         interface = event.content['interface']
         interface.deactivate()
-        self.handle_interface_link_down(event)
+        self.handle_interface_link_down(interface)
         self.notify_topology_update()
 
     @listen_to('.*.switch.interface.deleted')

--- a/main.py
+++ b/main.py
@@ -675,6 +675,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def handle_link_down(self, interface):
         """Notify a link is down."""
+        interface.deactivate()
         link = self._get_link_from_interface(interface)
         if link and link.is_active():
             link.deactivate()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'topology'
-NAPP_VERSION = '3.7.2'
+NAPP_VERSION = '3.8.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1125,6 +1125,8 @@ class TestMain(TestCase):
         self.napp.handle_link_down(mock_interface)
         mock_interface.deactivate.assert_called()
         mock_link.deactivate.assert_called()
+        mock_topology_update.assert_called()
+        mock_status_change.assert_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_or_create')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1105,6 +1105,22 @@ class TestMain(TestCase):
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
 
+    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
+    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
+    def test_handle_link_down(self, *args):
+        """Test interface link down."""
+        (mock_status_change, mock_topology_update,
+         mock_link_from_interface) = args
+
+        mock_interface = create_autospec(Interface)
+        mock_link = create_autospec(Link)
+        mock_link.is_active.return_value = True
+        mock_link_from_interface.return_value = mock_link
+        self.napp.handle_link_down(mock_interface)
+        mock_interface.deactivate.assert_called()
+        mock_link.deactivate.assert_called()
+
     @patch('napps.kytos.topology.main.Main._get_link_or_create')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     def test_add_links(self, *args):


### PR DESCRIPTION
Fixes #35 

### Release notes

```
[3.8.0] - 2021-12-22
```

#### Changed

- Fixed ``handle_link_down`` to also deactivate the interface

Now the same diff as presented in the original issue is correct, notice that `00:00:00:00:00:00:00:02:2"` is also down, because it's the other end of the veth pair see the `LOWERLAYERDOWN` below for more info: 

```
--- before.json 2021-12-22 11:38:02.277432565 -0300
+++ after.json  2021-12-22 11:38:20.427448498 -0300
@@ -68,10 +68,10 @@
                 "metadata": {}
             },
             "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260": {
-                "active": true,
+                "active": false,
                 "enabled": true,
                 "endpoint_a": {
-                    "active": true,
+                    "active": false,
                     "enabled": true,
                     "id": "00:00:00:00:00:00:00:02:2",
                     "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
@@ -101,7 +101,7 @@
                     "uni": false
                 },
                 "endpoint_b": {
-                    "active": true,
+                    "active": false,
                     "enabled": true,
                     "id": "00:00:00:00:00:00:00:01:2",
                     "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
@@ -175,7 +175,7 @@
                         "uni": true
                     },
                     "00:00:00:00:00:00:00:01:2": {
-                        "active": true,
+                        "active": false,
                         "enabled": true,
                         "id": "00:00:00:00:00:00:00:01:2",
                         "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
@@ -286,7 +286,7 @@
                         "uni": true
                     },
                     "00:00:00:00:00:00:00:02:2": {
-                        "active": true,
+                        "active": false,
                         "enabled": true,
                         "id": "00:00:00:00:00:00:00:02:2",
                         "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",

```

```
❯ sudo ip link show dev s1-eth2
43: s1-eth2@s2-eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noqueue master ovs-system state DOWN mode DEFAULT group default qlen 1000
    link/ether c2:41:ba:72:f9:db brd ff:ff:ff:ff:ff:ff

❯ sudo ip link show dev s2-eth2
44: s2-eth2@s1-eth2: <NO-CARRIER,BROADCAST,MULTICAST,UP,M-DOWN> mtu 1500 qdisc noqueue master ovs-system state LOWERLAYERDOWN mode DEFAULT group default qlen 1000
    link/ether ae:12:78:fd:88:fb brd ff:ff:ff:ff:ff:ff

```

