### PR TITLE
[Fix] Added support to store and load interface `available_tags`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,19 @@ Fixed
 Security
 ========
 
+[3.10.0] - 2022-01-19
+*********************
+
+Changed
+=======
+- Changed ``_load_link`` to try to also load interface available tags
+- Changed ``save_status_on_storehouse`` to also store interface available_tags
+
+Added
+=====
+- Subscribed to ``kytos/mef_eline.link_available_tags`` events
+- Added ``_load_intf_available_tags`` to try to load and set available_Tags
+- Added ``_get_links_dict_with_tags`` to also have interface available_tags
 
 [3.9.0] - 2021-12-22
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Changed
 
 Added
 =====
-- Subscribed to ``kytos/mef_eline.link_available_tags`` events
+- Subscribed to ``kytos/*.link_available_tags`` events
 - Added ``_load_intf_available_tags`` to try to load and set available_Tags
 - Added ``_get_links_dict_with_tags`` to also have interface available_tags
 - Hooked ``_load_intf_available_tags`` to be called for interface_created

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Added
 - Subscribed to ``kytos/mef_eline.link_available_tags`` events
 - Added ``_load_intf_available_tags`` to try to load and set available_Tags
 - Added ``_get_links_dict_with_tags`` to also have interface available_tags
+- Hooked ``_load_intf_available_tags`` to be called for interface_created
 
 [3.9.0] - 2021-12-22
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Changed
 
 Added
 =====
-- Subscribed to ``kytos/*.link_available_tags`` events
+- Subscribed to ``kytos/.*.link_available_tags`` events
 - Added ``_load_intf_available_tags`` to try to load and set available_Tags
 - Added ``_get_links_dict_with_tags`` to also have interface available_tags
 - Hooked ``_load_intf_available_tags`` to be called for interface_created

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp", "kytos/storehouse"],
   "license": "MIT",
   "tags": ["topology", "rest", "work-in-progress"],

--- a/main.py
+++ b/main.py
@@ -141,7 +141,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 return link
         return None
 
-    def _load_intf_available_tags(self, interface, intf_dict):
+    @staticmethod
+    def _load_intf_available_tags(interface, intf_dict):
         """Load interface available tags given its dict."""
         available_tags = intf_dict.get("available_tags", [])
         if available_tags:
@@ -820,19 +821,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_network_status_updated(self) -> None:
         """Handle *.network_status.updated events, specially from of_lldp."""
         self.save_status_on_storehouse()
-
-    def _update_interface_dict(self, links_dict, interface_id, interface_dict):
-        """Update interface dict."""
-        if not interface_id or not interface_dict:
-            return
-        links = dict(links_dict)
-        for link in links["links"].values():
-            for endpoint in ("endpoint_a", "endpoint_b"):
-                if not link[endpoint]["id"] == interface_id:
-                    continue
-                for k, v in interface_dict.items():
-                    link[endpoint].update(interface_dict)
-        return links
 
     def save_status_on_storehouse(self):
         """Save the network administrative status using storehouse."""

--- a/main.py
+++ b/main.py
@@ -620,13 +620,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface = event.content['interface']
 
         with self._links_lock:
-            available_tags = self.intf_available_tags.get(interface.id, [])
-            interface_dict = {"available_tags": available_tags}
-            if self._load_intf_available_tags(interface, interface_dict):
-                log.info(
-                    f"Loaded {len(interface.available_tags)}"
-                    f" available tags for {interface.id}"
-                )
+            if interface.id in self.intf_available_tags:
+                available_tags = self.intf_available_tags[interface.id]
+                interface_dict = {"available_tags": available_tags}
+                if self._load_intf_available_tags(interface, interface_dict):
+                    log.info(
+                        f"Loaded {len(interface.available_tags)}"
+                        f" available tags for {interface.id}"
+                    )
 
         self.update_instance_metadata(interface)
         self.handle_interface_link_up(interface)

--- a/main.py
+++ b/main.py
@@ -556,7 +556,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_metadata_changes(link, 'removed')
         return jsonify("Operation successful"), 200
 
-    @listen_to("kytos/*.link_available_tags")
+    @listen_to("kytos/.*.link_available_tags")
     def on_link_available_tags(self, event):
         """Handle on_link_available_tags."""
         with self._links_lock:

--- a/main.py
+++ b/main.py
@@ -556,7 +556,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_metadata_changes(link, 'removed')
         return jsonify("Operation successful"), 200
 
-    @listen_to("kytos/mef_eline.link_available_tags")
+    @listen_to("kytos/*.link_available_tags")
     def on_link_available_tags(self, event):
         """Handle on_link_available_tags."""
         with self._links_lock:

--- a/main.py
+++ b/main.py
@@ -617,9 +617,19 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         created event again and it can be belong to a link.
         """
         interface = event.content['interface']
-        self.notify_topology_update()
+
+        with self._links_lock:
+            available_tags = self.intf_available_tags.get(interface.id, [])
+            interface_dict = {"available_tags": available_tags}
+            if self._load_intf_available_tags(interface, interface_dict):
+                log.info(
+                    f"Loaded {len(interface.available_tags)}"
+                    f" available tags for {interface.id}"
+                )
+
         self.update_instance_metadata(interface)
         self.handle_interface_link_up(interface)
+        self.notify_topology_update()
 
     @listen_to('.*.switch.interface.created')
     def on_interface_created(self, event):

--- a/main.py
+++ b/main.py
@@ -144,10 +144,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @staticmethod
     def _load_intf_available_tags(interface, intf_dict):
         """Load interface available tags given its dict."""
-        available_tags = intf_dict.get("available_tags", [])
-        if available_tags:
-            interface.set_available_tags(available_tags)
-        return available_tags
+        has_available_tags = "available_tags" in intf_dict
+        if has_available_tags:
+            interface.set_available_tags(intf_dict["available_tags"])
+        return has_available_tags
 
     def _load_link(self, link_att):
         dpid_a = link_att['endpoint_a']['switch']

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,duplicate-code --ignored-modules=napps.kytos.topology
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,duplicate-code,too-many-lines,too-many-locals --ignored-modules=napps.kytos.topology
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'topology'
-NAPP_VERSION = '3.9.0'
+NAPP_VERSION = '3.10.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -151,7 +151,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.end_link',
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
-                           'kytos/mef_eline.link_available_tags',
+                           'kytos/*.link_available_tags',
                            '.*.network_status.updated',
                            '.*.interface.is.nni',
                            '.*.connection.lost',

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -151,7 +151,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.end_link',
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
-                           'kytos/*.link_available_tags',
+                           'kytos/.*.link_available_tags',
                            '.*.network_status.updated',
                            '.*.interface.is.nni',
                            '.*.connection.lost',

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -151,6 +151,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.end_link',
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
+                           'kytos/mef_eline.link_available_tags',
                            '.*.network_status.updated',
                            '.*.interface.is.nni',
                            '.*.connection.lost',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1034,12 +1034,13 @@ class TestMain(TestCase):
         self.napp.handle_connection_lost(mock_event)
         mock_notify_topology_update.assert_called()
 
+    @patch('napps.kytos.topology.main.Main._load_intf_available_tags')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_up')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.update_instance_metadata')
     def test_handle_interface_created(self, *args):
         """Test handle_interface_created."""
-        (mock_metadata, mock_notify, mock_link_up) = args
+        (mock_metadata, mock_notify, mock_link_up, mock_tags) = args
         mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
         mock_event.content['interface'] = mock_interface
@@ -1047,6 +1048,7 @@ class TestMain(TestCase):
         mock_notify.assert_called()
         mock_metadata.assert_called()
         mock_link_up.assert_called()
+        mock_tags.assert_called()
 
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_down')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1405,9 +1405,7 @@ class TestMain(TestCase):
         intf_dict = {}
         assert not self.napp._load_intf_available_tags(intf, intf_dict)
 
-        available_tags = [10]
-        intf_dict["available_tags"] = available_tags
-        assert (
-            self.napp._load_intf_available_tags(intf, intf_dict)
-            == available_tags
-        )
+        for available_tags in ([1, 10], [10], []):
+            with self.subTest(available_tags=available_tags, intf_dict={}):
+                intf_dict["available_tags"] = available_tags
+                assert self.napp._load_intf_available_tags(intf, intf_dict)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -43,7 +43,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
                            'kytos/storehouse.loaded',
-                           'kytos/*.link_available_tags',
+                           'kytos/.*.link_available_tags',
                            '.*.network_status.updated',
                            '.*.interface.is.nni',
                            '.*.connection.lost',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1043,7 +1043,11 @@ class TestMain(TestCase):
         (mock_metadata, mock_notify, mock_link_up, mock_tags) = args
         mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
-        mock_event.content['interface'] = mock_interface
+        mock_interface.id = "1"
+        available_tags = [1, 2, 3]
+        mock_interface.available_tags = []
+        mock_event.content = {'interface': mock_interface}
+        self.napp.intf_available_tags[mock_interface.id] = available_tags
         self.napp.handle_interface_created(mock_event)
         mock_notify.assert_called()
         mock_metadata.assert_called()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -43,7 +43,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
                            'kytos/storehouse.loaded',
-                           'kytos/mef_eline.link_available_tags',
+                           'kytos/*.link_available_tags',
                            '.*.network_status.updated',
                            '.*.interface.is.nni',
                            '.*.connection.lost',


### PR DESCRIPTION
Fixes #42 

### Release notes

version `[3.10.0] - 2022-01-19`

#### Changed

- Changed ``_load_link`` to try to also load interface available tags
- Changed ``save_status_on_storehouse`` to also store interface available_tags

#### Added

- Subscribed to ``kytos/*.link_available_tags`` events
- Added ``_load_intf_available_tags`` to try to load and set available_Tags
- Added ``_get_links_dict_with_tags`` to also have interface available_tags
- Hooked ``_load_intf_available_tags`` to be called for interface_created

#### Additional exploratory tests

I've simulated the following exploratory test:

- Created a L2VPN, to make sure it used a tag, so links would have 4094 tags available
- Forced a reconnection, when switches reconnected it loaded correctly the number of available tags
- Removed a L2VPN to make sure it was also freeing the tag correctly (back to 4095 tags)

Reconnection part:

```
kytos $> 2022-01-19 19:29:24,103 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60704
2022-01-19 19:29:24,103 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:60704. Reason: Request closed by client
2022-01-19 19:29:24,297 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60706
2022-01-19 19:29:24,298 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60708
2022-01-19 19:29:24,298 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60710
2022-01-19 19:29:24,324 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_8) Connection ('127.0.0.1', 60710), Switch 00:00:00:00:00:00:00:02: OPENFLOW HANDSHAKE COMPLETE
2022-01-19 19:29:24,329 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_1) Connection ('127.0.0.1', 60706), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2022-01-19 19:29:24,340 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_5) Connection ('127.0.0.1', 60708), Switch 00:00:00:00:00:00:00:03: OPENFLOW HANDSHAKE COMPLETE
2022-01-19 19:29:24,340 - INFO [kytos.napps.kytos/flow_manager] (Thread-29) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [{
'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-01-19 19:29:24,341 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_0) Modified Interface('s2', 4294967294, Switch('00:00:00:00:00:00:00:02')) 00:00:00:00:00:00:00:02:42949
67294
2022-01-19 19:29:24,349 - INFO [kytos.napps.kytos/of_core] (ThreadPoolExecutor-0_0) The port 4294967294 from switch 00:00:00:00:00:00:00:02 was modified, reason OFPPR_MODIFY.
2022-01-19 19:29:24,356 - INFO [kytos.napps.kytos/flow_manager] (Thread-27) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False, flows_dict: {'flows': [{
'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677058, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-01-19 19:29:24,362 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_3) Flow saved in kytos.flow.persistence.7938b87c300e495b847246e5003a3aee
2022-01-19 19:29:24,365 - INFO [kytos.napps.kytos/flow_manager] (Thread-32) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False, flows_dict: {'flows': [{
'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677059, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-01-19 19:29:24,375 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_2) Loaded 4094 available tags for 00:00:00:00:00:00:00:01:2
2022-01-19 19:29:24,377 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_9) Flow saved in kytos.flow.persistence.7938b87c300e495b847246e5003a3aee
2022-01-19 19:29:24,387 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_4) Loaded 4094 available tags for 00:00:00:00:00:00:00:03:2
2022-01-19 19:29:24,397 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_0) Flow saved in kytos.flow.persistence.7938b87c300e495b847246e5003a3aee
2022-01-19 19:29:24,408 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_9) Flow saved in kytos.flow.persistence.7938b87c300e495b847246e5003a3aee
2022-01-19 19:29:24,410 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_6) Loaded 4094 available tags for 00:00:00:00:00:00:00:02:2
2022-01-19 19:29:24,416 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_2) Loaded 4094 available tags for 00:00:00:00:00:00:00:02:3
2022-01-19 19:29:24,429 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_1) Flow saved in kytos.flow.persistence.7938b87c300e495b847246e5003a3aee
2022-01-19 19:29:24,473 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_11) Flow saved in kytos.flow.persistence.7938b87c300e495b847246e5003a3aee

```

After removing the VPN and restarting the controller:

```
2022-01-19 19:30:05,696 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading switch from storehouse dpid=00:00:00:00:00:00:00:01
kytos $> 2022-01-19 19:30:05,726 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:01:4294967294
2022-01-19 19:30:05,737 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:01:1
2022-01-19 19:30:05,748 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:01:2
2022-01-19 19:30:05,758 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading switch from storehouse dpid=00:00:00:00:00:00:00:02
2022-01-19 19:30:05,762 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:02:4294967294
2022-01-19 19:30:05,772 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:02:1
2022-01-19 19:30:05,783 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:02:2
2022-01-19 19:30:05,793 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:02:3
2022-01-19 19:30:05,847 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading switch from storehouse dpid=00:00:00:00:00:00:00:03
2022-01-19 19:30:05,849 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:03:4294967294
2022-01-19 19:30:05,856 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:03:1
2022-01-19 19:30:05,862 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading interface iface_id=00:00:00:00:00:00:00:03:2
2022-01-19 19:30:05,869 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading link from storehouse 00:00:00:00:00:00:00:01:2-00:00:00:00:00:00:00:02:2
2022-01-19 19:30:05,875 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loaded 4095 available tags for 00:00:00:00:00:00:00:01:2
2022-01-19 19:30:05,879 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loaded 4095 available tags for 00:00:00:00:00:00:00:02:2
2022-01-19 19:30:05,879 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loading link from storehouse 00:00:00:00:00:00:00:02:3-00:00:00:00:00:00:00:03:2
2022-01-19 19:30:05,885 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loaded 4095 available tags for 00:00:00:00:00:00:00:02:3
2022-01-19 19:30:05,889 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_0) Loaded 4095 available tags for 00:00:00:00:00:00:00:03:2
2022-01-19 19:30:05,890 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading switch from storehouse dpid=00:00:00:00:00:00:00:01
2022-01-19 19:30:05,891 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:01:4294967294
2022-01-19 19:30:05,894 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:01:1
2022-01-19 19:30:05,894 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:01:2
2022-01-19 19:30:05,895 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading switch from storehouse dpid=00:00:00:00:00:00:00:02
2022-01-19 19:30:05,897 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:02:4294967294
2022-01-19 19:30:05,898 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:02:1
2022-01-19 19:30:05,900 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:02:2
2022-01-19 19:30:05,902 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:02:3
2022-01-19 19:30:05,902 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading switch from storehouse dpid=00:00:00:00:00:00:00:03
2022-01-19 19:30:05,904 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:03:4294967294
2022-01-19 19:30:05,906 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:03:1
2022-01-19 19:30:05,907 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading interface iface_id=00:00:00:00:00:00:00:03:2
2022-01-19 19:30:05,909 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading link from storehouse 00:00:00:00:00:00:00:01:2-00:00:00:00:00:00:00:02:2
2022-01-19 19:30:05,914 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loaded 4095 available tags for 00:00:00:00:00:00:00:01:2
2022-01-19 19:30:05,918 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loaded 4095 available tags for 00:00:00:00:00:00:00:02:2
2022-01-19 19:30:05,918 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loading link from storehouse 00:00:00:00:00:00:00:02:3-00:00:00:00:00:00:00:03:2
2022-01-19 19:30:05,925 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loaded 4095 available tags for 00:00:00:00:00:00:00:02:3
2022-01-19 19:30:05,929 - INFO [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_5) Loaded 4095 available tags for 00:00:00:00:00:00:00:03:2
2022-01-19 19:30:06,163 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60724
2022-01-19 19:30:06,163 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60726
2022-01-19 19:30:06,163 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60728

```