### PR TITLE
[Fix] call `notify_topology_update()` when interface goes down/up or when entities are disabled/enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,16 @@ Fixed
 Security
 ========
 
+[2022.1.0] - 2022-01-25
+***********************
+
+Changed
+=======
+- Hooked ``notify_topology_update`` to be called at least once if an interface goes up or down
+- Updated rest endpoints that disable entities to notify topology update
+- Updated rest endpoints that enable entities to notify topology update
+- Changed status code from 409 to 404 when interfaces aren't found
+
 [3.10.1] - 2022-01-20
 *********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "3.11.0",
+  "version": "2022.1.0",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp", "kytos/storehouse"],
   "license": "MIT",
   "tags": ["topology", "rest", "work-in-progress"],

--- a/main.py
+++ b/main.py
@@ -314,6 +314,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                  " to disabled.")
         self.save_status_on_storehouse()
         self.notify_switch_disabled(dpid)
+        self.notify_topology_update()
         return jsonify("Operation successful"), 201
 
     @rest('v3/switches/<dpid>/metadata')
@@ -419,6 +420,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if not error_list:
             log.info("Storing administrative state for disabled interfaces.")
             self.save_status_on_storehouse()
+            self.notify_topology_update()
             return jsonify("Operation successful"), 200
         return jsonify({msg_error:
                         error_list}), 409
@@ -519,6 +521,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             self.links[link_id],
             reason='link disabled'
         )
+        self.notify_topology_update()
         return jsonify("Operation successful"), 201
 
     @rest('v3/links/<link_id>/metadata')

--- a/main.py
+++ b/main.py
@@ -758,7 +758,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.update_metadata('last_status_change', time.time())
             link.update_metadata('last_status_is_active', False)
             self.notify_link_status_change(link, reason='link down')
-            self.notify_topology_update()
         if link and not link.is_active():
             with self._links_lock:
                 last_status = link.get_metadata('last_status_is_active')
@@ -766,7 +765,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                     link.update_metadata('last_status_is_active', False)
                     link.update_metadata('last_status_change', time.time())
                     self.notify_link_status_change(link, reason='link down')
-                    self.notify_topology_update()
         interface.deactivate()
         self.notify_topology_update()
 

--- a/main.py
+++ b/main.py
@@ -300,6 +300,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                  " to enabled.")
         self.save_status_on_storehouse()
         self.notify_switch_enabled(dpid)
+        self.notify_topology_update()
         return jsonify("Operation successful"), 201
 
     @rest('v3/switches/<dpid>/disable', methods=['POST'])
@@ -390,6 +391,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if not error_list:
             log.info("Storing administrative state for enabled interfaces.")
             self.save_status_on_storehouse()
+            self.notify_topology_update()
             return jsonify("Operation successful"), 200
         return jsonify({msg_error:
                         error_list}), 409
@@ -506,6 +508,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             self.links[link_id],
             reason='link enabled'
         )
+        self.notify_topology_update()
         return jsonify("Operation successful"), 201
 
     @rest('v3/links/<link_id>/disable', methods=['POST'])

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'topology'
-NAPP_VERSION = '3.10.1'
+NAPP_VERSION = '2022.1.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -711,7 +711,7 @@ class TestMain(TestCase):
         mock_interface_2.enable.call_count = 0
         url = f'{self.server_name_url}/v3/interfaces/{interface_id}/enable'
         response = api.post(url)
-        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(response.status_code, 404, response.data)
         self.assertEqual(mock_interface_1.enable.call_count, 0)
         self.assertEqual(mock_interface_2.enable.call_count, 0)
 
@@ -758,7 +758,7 @@ class TestMain(TestCase):
         mock_interface_2.disable.call_count = 0
         url = f'{self.server_name_url}/v3/interfaces/{interface_id}/disable'
         response = api.post(url)
-        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(response.status_code, 404, response.data)
         self.assertEqual(mock_interface_1.disable.call_count, 0)
         self.assertEqual(mock_interface_2.disable.call_count, 0)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1140,7 +1140,7 @@ class TestMain(TestCase):
         self.napp.handle_link_down(mock_interface)
         mock_interface.deactivate.assert_called()
         mock_link.deactivate.assert_called()
-        assert mock_topology_update.call_count == 2
+        assert mock_topology_update.call_count == 1
         mock_status_change.assert_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1036,11 +1036,10 @@ class TestMain(TestCase):
 
     @patch('napps.kytos.topology.main.Main._load_intf_available_tags')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_up')
-    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.update_instance_metadata')
     def test_handle_interface_created(self, *args):
         """Test handle_interface_created."""
-        (mock_metadata, mock_notify, mock_link_up, mock_tags) = args
+        (mock_metadata, mock_link_up, mock_tags) = args
         mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
         mock_interface.id = "1"
@@ -1049,22 +1048,18 @@ class TestMain(TestCase):
         mock_event.content = {'interface': mock_interface}
         self.napp.intf_available_tags[mock_interface.id] = available_tags
         self.napp.handle_interface_created(mock_event)
-        mock_notify.assert_called()
         mock_metadata.assert_called()
         mock_link_up.assert_called()
         mock_tags.assert_called()
 
-    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_down')
-    def test_handle_interface_down(self, *args):
+    def test_handle_interface_down(self, mock_handle_interface_link_down):
         """Test handle interface down."""
-        (mock_handle_interface_link_down, mock_notify_topology_update) = args
         mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
         mock_event.content['interface'] = mock_interface
         self.napp.handle_interface_down(mock_event)
         mock_handle_interface_link_down.assert_called()
-        mock_notify_topology_update.assert_called()
 
     @patch('napps.kytos.topology.main.Main.handle_interface_down')
     def test_interface_deleted(self, mock_handle_interface_link_down):
@@ -1132,7 +1127,7 @@ class TestMain(TestCase):
         self.napp.handle_link_down(mock_interface)
         mock_interface.deactivate.assert_called()
         mock_link.deactivate.assert_called()
-        mock_topology_update.assert_called()
+        assert mock_topology_update.call_count == 2
         mock_status_change.assert_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
@@ -1167,7 +1162,7 @@ class TestMain(TestCase):
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_up(mock_interface)
         mock_interface.activate.assert_called()
-        mock_topology_update.assert_called()
+        assert mock_topology_update.call_count == 2
         mock_status_change.assert_called()
 
     @patch('time.sleep')
@@ -1186,8 +1181,7 @@ class TestMain(TestCase):
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_up(mock_interface)
         mock_interface.activate.assert_called()
-
-        mock_topology_update.assert_not_called()
+        assert mock_topology_update.call_count == 1
         mock_status_change.assert_not_called()
 
     @patch('napps.kytos.topology.main.Main.update_instance_metadata')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -572,9 +572,11 @@ class TestMain(TestCase):
         self.assertEqual(response.status_code, 404, response.data)
         self.assertEqual(mock_switch.enable.call_count, 0)
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
-    def test_disable_switch(self, mock_save_status):
+    def test_disable_switch(self, *args):
         """Test disable_switch."""
+        mock_save_status, mock_notify_topo = args
         dpid = "00:00:00:00:00:00:00:01"
         mock_switch = get_switch_mock(dpid)
         self.napp.controller.switches = {dpid: mock_switch}
@@ -585,6 +587,7 @@ class TestMain(TestCase):
         self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(mock_switch.disable.call_count, 1)
         mock_save_status.assert_called()
+        mock_notify_topo.assert_called()
 
         # fail case
         mock_switch.disable.call_count = 0
@@ -716,8 +719,9 @@ class TestMain(TestCase):
         self.assertEqual(mock_interface_1.enable.call_count, 0)
         self.assertEqual(mock_interface_2.enable.call_count, 0)
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
-    def test_disable_interfaces(self, mock_save_status):
+    def test_disable_interfaces(self, mock_save_status, mock_notify_topo):
         """Test disable_interfaces."""
         interface_id = '00:00:00:00:00:00:00:01:1'
         dpid = '00:00:00:00:00:00:00:01'
@@ -734,6 +738,7 @@ class TestMain(TestCase):
         self.assertEqual(mock_interface_1.disable.call_count, 1)
         self.assertEqual(mock_interface_2.disable.call_count, 0)
         mock_save_status.assert_called()
+        mock_notify_topo.assert_called()
 
         mock_interface_1.disable.call_count = 0
         mock_interface_2.disable.call_count = 0
@@ -897,8 +902,9 @@ class TestMain(TestCase):
         response = api.post(url)
         self.assertEqual(response.status_code, 404, response.data)
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
-    def test_disable_link(self, mock_save_status):
+    def test_disable_link(self, mock_save_status, mock_notify_topo):
         """Test disable_link."""
         mock_link = MagicMock(Link)
         self.napp.links = {'1': mock_link}
@@ -910,6 +916,7 @@ class TestMain(TestCase):
         response = api.post(url)
         self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(mock_link.disable.call_count, 1)
+        self.assertEqual(mock_notify_topo.call_count, 1)
 
         # fail case
         link_id = 2

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -550,8 +550,9 @@ class TestMain(TestCase):
         with self.assertRaises(RestoreError):
             self.napp._load_link(link_attrs_fail)
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
-    def test_enable_switch(self, mock_save_status):
+    def test_enable_switch(self, mock_save_status, mock_notify_topo):
         """Test enable_switch."""
         dpid = "00:00:00:00:00:00:00:01"
         mock_switch = get_switch_mock(dpid)
@@ -563,6 +564,7 @@ class TestMain(TestCase):
         self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(mock_switch.enable.call_count, 1)
         mock_save_status.assert_called()
+        mock_notify_topo.assert_called()
 
         # fail case
         mock_switch.enable.call_count = 0
@@ -674,8 +676,9 @@ class TestMain(TestCase):
         self.assertEqual(mock_metadata_changes.call_count, 1)  # remains 1 call
         self.assertEqual(response.status_code, 404, response.data)
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
-    def test_enable_interfaces(self, mock_save_status):
+    def test_enable_interfaces(self, mock_save_status, mock_notify_topo):
         """Test enable_interfaces."""
         dpid = '00:00:00:00:00:00:00:01'
         mock_switch = get_switch_mock(dpid)
@@ -692,6 +695,7 @@ class TestMain(TestCase):
         self.assertEqual(mock_interface_1.enable.call_count, 1)
         self.assertEqual(mock_interface_2.enable.call_count, 0)
         mock_save_status.assert_called()
+        mock_notify_topo.assert_called()
 
         mock_interface_1.enable.call_count = 0
         mock_interface_2.enable.call_count = 0
@@ -882,8 +886,9 @@ class TestMain(TestCase):
         response = api.delete(url)
         self.assertEqual(response.status_code, 404, response.data)
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.save_status_on_storehouse')
-    def test_enable_link(self, mock_save_status):
+    def test_enable_link(self, mock_save_status, mock_notify_topo):
         """Test enable_link."""
         mock_link = MagicMock(Link)
         self.napp.links = {'1': mock_link}
@@ -895,6 +900,7 @@ class TestMain(TestCase):
         response = api.post(url)
         self.assertEqual(response.status_code, 201, response.data)
         self.assertEqual(mock_link.enable.call_count, 1)
+        mock_notify_topo.assert_called()
 
         # fail case
         link_id = 2


### PR DESCRIPTION
Fixes #49 

Fixed calling `notify_topology_update()` when interface goes down/up or when entities are disabled/enabled, just so subscribers like `pathfinder` have the updated graph. 

### Release notes

#### Changed

- Hooked ``notify_topology_update`` to be called at least once if an interface goes up or down
- Updated rest endpoints that disable entities to notify topology update
- Updated rest endpoints that enable entities to notify topology update
- Changed status code from 409 to 404 when interfaces aren't found
