### PR TITLE
Update setup to make it compatible with py39

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,6 +283,7 @@ setup(name=f'kytos_{NAPP_NAME}',
       install_requires=read_requirements(),
       setup_requires=['pytest-runner'],
       tests_require=['pytest==7.0.0'],
+      packages=[],
       extras_require={
           'dev': [
               'coverage',


### PR DESCRIPTION
Same as described in this comment https://github.com/kytos-ng/flow_stats/pull/18#discussion_r852213307, this PR includes an empty packages directive to setuptools. All credits to @viniarck who found and documented the solution.

### Description of the change

- Adds an empty `packages` directive to `setup.py` to make it compatible with py39 (as described here: https://github.com/kytos-ng/flow_stats/pull/18#discussion_r852213307)

### Release notes

N/A