### PR TITLE
[Feature] Subscribed to link liveness events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,10 +20,12 @@ Added
 - TopoController and DB models
 - ``storehouse_to_mongo.py`` script to migrate data from storehouse to MongoDB
 - Retries to handle database ``AutoReconnect`` exception.
+- Topology now reacts to link liveness detection events.
 
 Changed
 =======
 - Refactored API and event handlers to also update MongoDB accordingly.
+- ``kytos/topology.link_up`` is only published if link.status is EntityStatus.UP, which takes into account other protocol logical states.
 
 Deprecated
 ==========

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ Subscribed
 - ``kytos/maintenance.end_link``
 - ``kytos/maintenance.start_switch``
 - ``kytos/maintenance.end_switch``
+- ``kytos/.*.liveness.(up|down)``
+- ``kytos/.*.liveness.disabled``
 
 
 Published

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -315,6 +315,15 @@ class TopoController:
         """Try to find a link and delete a metadata key."""
         return self._update_link(link_id, {"$unset": {f"metadata.{key}": ""}})
 
+    def bulk_delete_link_metadata_key(
+        self, link_ids: List[str], key: str
+    ) -> Optional[dict]:
+        """Bulk delelete link metadata key."""
+        update_expr = {"$unset": {f"metadata.{key}": 1}}
+        self._set_updated_at(update_expr)
+        return self.db.links.update_many({"_id": {"$in": link_ids}},
+                                         update_expr)
+
     def bulk_upsert_interface_details(
         self, ids_details: List[Tuple[str, dict]]
     ) -> Optional[dict]:

--- a/main.py
+++ b/main.py
@@ -537,7 +537,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_metadata_changes(link, 'removed')
         return jsonify("Operation successful"), 200
 
-    @listen_to("kytos/.*.liveness.(up|down|init)")
+    @listen_to("kytos/.*.liveness.(up|down)")
     def on_link_liveness(self, event) -> None:
         """Handle link liveness up event."""
         link = Link(event.content["interface_a"], event.content["interface_b"])
@@ -730,8 +730,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 link.update_metadata('last_status_is_active', True)
                 self.topo_controller.activate_link(link.id, last_status_change,
                                                    last_status_is_active=True)
-                self.notify_topology_update()
-                self.notify_link_status_change(link, reason='link up')
+                if link.status == EntityStatus.UP:
+                    self.notify_topology_update()
+                    self.notify_link_status_change(link, reason='link up')
         else:
             last_status_change = time.time()
             metadata = {'last_status_change': last_status_change,
@@ -739,8 +740,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.extend_metadata(metadata)
             self.topo_controller.activate_link(link.id, last_status_change,
                                                last_status_is_active=True)
-            self.notify_topology_update()
-            self.notify_link_status_change(link, reason='link up')
+            if link.status == EntityStatus.UP:
+                self.notify_topology_update()
+                self.notify_link_status_change(link, reason='link up')
 
     @listen_to('.*.switch.interface.link_down')
     def on_interface_link_down(self, event):

--- a/main.py
+++ b/main.py
@@ -556,8 +556,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller.add_link_metadata(link.id, metadata)
         link.extend_metadata(metadata)
         self.notify_topology_update()
-        self.notify_link_status_change(link,
-                                       reason=f"liveness_{liveness_status}")
+        if link.status == EntityStatus.UP and liveness_status == "up":
+            self.notify_link_status_change(link, reason="liveness_up")
+        if link.status != EntityStatus.UP and liveness_status == "down":
+            self.notify_link_status_change(link, reason="liveness_down")
 
     @listen_to("kytos/.*.liveness.disabled")
     def on_link_liveness_disabled(self, event) -> None:

--- a/main.py
+++ b/main.py
@@ -538,8 +538,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         return jsonify("Operation successful"), 200
 
     @listen_to("kytos/.*.liveness.(up|down)")
-    def on_link_liveness(self, event) -> None:
-        """Handle link liveness up|down event."""
+    def on_link_liveness_status(self, event) -> None:
+        """Handle link liveness up|down status event."""
         link = Link(event.content["interface_a"], event.content["interface_b"])
         try:
             link = self.links[link.id]
@@ -547,9 +547,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             log.error(f"Link id {link.id} not found, {link}")
             return
         liveness_status = event.name.split(".")[-1]
-        self.handle_link_liveness(self.links[link.id], liveness_status)
+        self.handle_link_liveness_status(self.links[link.id], liveness_status)
 
-    def handle_link_liveness(self, link, liveness_status) -> None:
+    def handle_link_liveness_status(self, link, liveness_status) -> None:
         """Handle link liveness."""
         metadata = {"liveness_status": liveness_status}
         log.info(f"Link liveness {liveness_status}: {link}")

--- a/main.py
+++ b/main.py
@@ -558,7 +558,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_topology_update()
         if link.status == EntityStatus.UP and liveness_status == "up":
             self.notify_link_status_change(link, reason="liveness_up")
-        if link.status != EntityStatus.UP and liveness_status == "down":
+        if link.status == EntityStatus.DOWN and liveness_status == "down":
             self.notify_link_status_change(link, reason="liveness_down")
 
     @listen_to("kytos/.*.liveness.disabled")

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -142,6 +142,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.end_switch',
                            'kytos/.*.link_available_tags',
                            'kytos/.*.liveness.(up|down)',
+                           'kytos/.*.liveness.disabled',
                            '.*.topo_controller.upsert_switch',
                            '.*.of_lldp.network_status.updated',
                            '.*.interface.is.nni',

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -141,6 +141,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
                            'kytos/.*.link_available_tags',
+                           'kytos/.*.liveness.(up|down|init)',
                            '.*.topo_controller.upsert_switch',
                            '.*.of_lldp.network_status.updated',
                            '.*.interface.is.nni',

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -141,7 +141,7 @@ class TestMain(TestCase):
                            'kytos/maintenance.start_switch',
                            'kytos/maintenance.end_switch',
                            'kytos/.*.link_available_tags',
-                           'kytos/.*.liveness.(up|down|init)',
+                           'kytos/.*.liveness.(up|down)',
                            '.*.topo_controller.upsert_switch',
                            '.*.of_lldp.network_status.updated',
                            '.*.interface.is.nni',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -18,7 +18,7 @@ from tests.unit.helpers import get_controller_mock, get_napp_urls
 
 
 @pytest.mark.parametrize("liveness_status", ("up", "down", "init"))
-def test_handle_link_liveness(liveness_status) -> None:
+def test_handle_link_liveness_status(liveness_status) -> None:
     """Test handle link liveness."""
     from napps.kytos.topology.main import Main
     Main.get_topo_controller = MagicMock()
@@ -27,7 +27,7 @@ def test_handle_link_liveness(liveness_status) -> None:
     napp.notify_link_status_change = MagicMock()
 
     link = MagicMock(id="some_id")
-    napp.handle_link_liveness(link, liveness_status)
+    napp.handle_link_liveness_status(link, liveness_status)
 
     add_link_meta = napp.topo_controller.add_link_metadata
     add_link_meta.assert_called_with(link.id, {"liveness_status":

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,7 @@ import time
 from unittest import TestCase
 from unittest.mock import MagicMock, create_autospec, patch
 
+from kytos.core.common import EntityStatus
 from kytos.core.interface import Interface
 from kytos.core.link import Link
 from kytos.core.switch import Switch
@@ -78,7 +79,7 @@ class TestMain(TestCase):
                            '.*.switch.interface.link_down',
                            '.*.switch.interface.link_up',
                            '.*.switch.(new|reconnected)',
-                           'kytos/.*.liveness.(up|down|init)',
+                           'kytos/.*.liveness.(up|down)',
                            '.*.switch.port.created']
         actual_events = self.napp.listeners()
         self.assertCountEqual(expected_events, actual_events)
@@ -1211,6 +1212,7 @@ class TestMain(TestCase):
         mock_link.endpoint_a = mock_interface_a
         mock_link.endpoint_b = mock_interface_b
         mock_link_from_interface.return_value = mock_link
+        mock_link.status = EntityStatus.UP
         self.napp.link_up_timer = 1
         self.napp.handle_interface_link_up(mock_interface_a)
         mock_topology_update.assert_called()
@@ -1283,7 +1285,7 @@ class TestMain(TestCase):
          mock_link_from_interface) = args
 
         mock_interface = create_autospec(Interface)
-        mock_link = MagicMock()
+        mock_link = MagicMock(status=EntityStatus.UP)
         mock_link.is_active.return_value = True
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_up(mock_interface)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -17,8 +17,10 @@ from napps.kytos.topology.exceptions import RestoreError
 from tests.unit.helpers import get_controller_mock, get_napp_urls
 
 
-@pytest.mark.parametrize("liveness_status", ("up", "down", "init"))
-def test_handle_link_liveness_status(liveness_status) -> None:
+@pytest.mark.parametrize("liveness_status, status",
+                         [("up", EntityStatus.UP),
+                          ("down", EntityStatus.DOWN)])
+def test_handle_link_liveness_status(liveness_status, status) -> None:
     """Test handle link liveness."""
     from napps.kytos.topology.main import Main
     Main.get_topo_controller = MagicMock()
@@ -26,7 +28,7 @@ def test_handle_link_liveness_status(liveness_status) -> None:
     napp.notify_topology_update = MagicMock()
     napp.notify_link_status_change = MagicMock()
 
-    link = MagicMock(id="some_id")
+    link = MagicMock(id="some_id", status=status)
     napp.handle_link_liveness_status(link, liveness_status)
 
     add_link_meta = napp.topo_controller.add_link_metadata


### PR DESCRIPTION
Fixes #69 

This PR implements the integration with link liveness events as described on this blueprint https://github.com/kytos-ng/kytos/pull/241. The link liveness events from topology's perspective are protocol agnostic, when the time comes to also have liveness via BFD it's expected to be similar as long as we reuse the same event patterns in the future. 

### Release notes

- Topology now reacts to link liveness detection events.
- ``kytos/topology.link_up`` is only published if link.status is EntityStatus.UP, which takes into account other protocol logical states.

### Demo

- I'm using a linear topology with 2 switches, once `kytos/.*.liveness.up` is received liveness goes up, and notice that `mef_eline` handles it as a link up:

```
2022-07-08 12:01:44,526 - INFO [kytos.napps.kytos/topology] (thread_pool_app_4) Link liveness up: Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01')))
2022-07-08 12:01:44,554 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_0) Event handle_link_up kytos/topology.link_up
kytos $>
```

Also, if you try to find a path via `pathfinder` it works as you'd expect:

```
❯ echo '{"source": "00:00:00:00:00:00:00:01:1", "destination": "00:00:00:00:00:00:00:02:1"}' | http http://127.0.0.1:8181/api/kytos/pathfinder/v2
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 196
Content-Type: application/json
Date: Fri, 08 Jul 2022 15:03:21 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{
    "paths": [
        {
            "cost": 5,
            "hops": [
                "00:00:00:00:00:00:00:01:1",
                "00:00:00:00:00:00:00:01",
                "00:00:00:00:00:00:00:01:2",
                "00:00:00:00:00:00:00:02:2",
                "00:00:00:00:00:00:00:02",
                "00:00:00:00:00:00:00:02:1"
            ]
        }
    ]
}
```

- Now simulating a liveness down event `kytos/.*.liveness.down`:

```
kytos $> 2022-07-08 12:03:45,189 - INFO [kytos.napps.kytos/topology] (thread_pool_app_1) Link liveness down: Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01')))
2022-07-08 12:03:45,213 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_0) Event handle_link_down kytos/topology.link_down
kytos $>
```

Notice that `mef_eline` handles it as a link down, and then if try to find a path via `pathfinder` it wouldn't return any path in this linear topology:

```
❯ echo '{"source": "00:00:00:00:00:00:00:01:1", "destination": "00:00:00:00:00:00:00:02:1"}' | http http://127.0.0.1:8181/api/kytos/pathfinder/v2
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 13
Content-Type: application/json
Date: Fri, 08 Jul 2022 15:03:52 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{
    "paths": []
}
```