### PR TITLE
Fix failing integration test

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -31,7 +31,7 @@ def get_switch_mock(of_version, connection_state=ConnectionState.NEW,
 
 def get_interface_mock(interface_name, port, *args, **kwargs):
     """Return a interface mock."""
-    switch = get_switch_mock
+    switch = get_switch_mock(0x04)
     switch.connection = Mock()
     switch.connection.protocol.version = 0x04
     iface = Interface(interface_name, port, switch, *args, **kwargs)


### PR DESCRIPTION
This integration test was passing before, thanks to the cached `id` property PR that has landed https://github.com/kytos-ng/kytos/pull/243 the error became evident here in this test case. ` tox` exec:

```
❯ tox
GLOB sdist-make: /home/viniarck/repos/topology/setup.py
py39 inst-nodeps: /home/viniarck/repos/topology/.tox/.tmp/package/1/kytos_topology-2022.1.0.zip
py39 installed: astroid==2.9.3,attrs==21.4.0,backcall==0.1.0,black==22.3.0,blinker==1.4,certifi==2021.10.8,click==8.1.3,coverage==6.2,decorator==4.4.2,distlib==0.3.4,docopt==0.6.2,docuti
ls==0.19,elastic-apm==6.9.1,filelock==3.4.1,Flask==1.1.2,Flask-Cors==3.0.8,Flask-SocketIO==4.2.1,iniconfig==1.1.1,ipython==7.13.0,ipython-genutils==0.2.0,isort==5.10.1,itsdangerous==1.1.
0,janus==0.4.0,jedi==0.16.0,Jinja2==2.11.1,-e git+https://github.com/kytos-ng/kytos.git@07e9cedf0eb3a0e4ab9f46bc591490e747f9ceb8#egg=kytos,lazy-object-proxy==1.7.1,lockfile==0.12.2,Marku
pSafe==1.1.1,mccabe==0.6.1,mypy-extensions==0.4.3,packaging==21.3,parso==0.6.2,pathspec==0.9.0,pathtools==0.1.2,pep517==0.12.0,pexpect==4.8.0,pickleshare==0.7.5,pip-tools==6.4.0,platform
dirs==2.4.0,pluggy==1.0.0,prompt-toolkit==3.0.5,ptyprocess==0.6.0,py==1.11.0,pycodestyle==2.8.0,pydantic==1.9.0,Pygments==2.12.0,PyJWT==1.7.1,pylint==2.12.2,pymongo==4.1.0,pyparsing==3.0
.6,pytest==7.0.0,pytest-cov==3.0.0,python-daemon==2.2.4,python-engineio==3.12.1,-e git+ssh://git@github.com/kytos-ng/topology.git@d13a83b770c2b991989ef3cd0d476fc83aa5e75f#egg=python_open
flow,python-socketio==4.5.1,six==1.16.0,tenacity==8.0.1,toml==0.10.2,tomli==1.2.3,tox==3.24.5,traitlets==4.3.3,typing_extensions==4.0.1,urllib3==1.26.7,virtualenv==20.13.0,watchdog==0.10
.2,wcwidth==0.1.9,Werkzeug==1.0.1,wrapt==1.13.3,yala==3.1.0
py39 run-test-pre: PYTHONHASHSEED='3943758090'
coverage installed: astroid==2.9.3,attrs==21.4.0,backcall==0.1.0,black==22.3.0,blinker==1.4,certifi==2021.10.8,click==8.1.3,coverage==6.2,decorator==4.4.2,distlib==0.3.4,docopt==0.6.2,do
cutils==0.19,elastic-apm==6.9.1,filelock==3.4.1,Flask==1.1.2,Flask-Cors==3.0.8,Flask-SocketIO==4.2.1,iniconfig==1.1.1,ipython==7.13.0,ipython-genutils==0.2.0,isort==5.10.1,itsdangerous==
1.1.0,janus==0.4.0,jedi==0.16.0,Jinja2==2.11.1,-e git+https://github.com/kytos-ng/kytos.git@07e9cedf0eb3a0e4ab9f46bc591490e747f9ceb8#egg=kytos,lazy-object-proxy==1.7.1,lockfile==0.12.2,M
arkupSafe==1.1.1,mccabe==0.6.1,mypy-extensions==0.4.3,packaging==21.3,parso==0.6.2,pathspec==0.9.0,pathtools==0.1.2,pep517==0.12.0,pexpect==4.8.0,pickleshare==0.7.5,pip-tools==6.4.0,plat
formdirs==2.4.0,pluggy==1.0.0,prompt-toolkit==3.0.5,ptyprocess==0.6.0,py==1.11.0,pycodestyle==2.8.0,pydantic==1.9.0,Pygments==2.12.0,PyJWT==1.7.1,pylint==2.12.2,pymongo==4.1.0,pyparsing=
=3.0.6,pytest==7.0.0,pytest-cov==3.0.0,python-daemon==2.2.4,python-engineio==3.12.1,-e git+ssh://git@github.com/kytos-ng/topology.git@d13a83b770c2b991989ef3cd0d476fc83aa5e75f#egg=python_
openflow,python-socketio==4.5.1,six==1.16.0,tenacity==8.0.1,toml==0.10.2,tomli==1.2.3,tox==3.24.5,traitlets==4.3.3,typing_extensions==4.0.1,urllib3==1.26.7,virtualenv==20.13.0,watchdog==
0.10.2,wcwidth==0.1.9,Werkzeug==1.0.1,wrapt==1.13.3,yala==3.1.0
coverage run-test-pre: PYTHONHASHSEED='3943758090'
coverage run-test: commands[0] | python3 setup.py coverage
running coverage
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.9.12, pytest-7.0.0, pluggy-1.0.0
cachedir: .tox/py39/.pytest_cache
rootdir: /home/viniarck/repos/topology
plugins: cov-3.0.0
collected 96 items

tests/integration/test_main.py .......                                                                                                                                             [  7%]
tests/unit/test_db_models.py ...                                                                                                                                                   [ 10%]
tests/unit/test_main.py ..........................................................                                                                                                 [ 70%]
tests/unit/test_model.py ..                                                                                                                                                        [ 72%]
tests/unit/test_topo_controller.py ..........................                                                                                                                      [100%]

==================================================================================== warnings 

---------- coverage: platform linux, python 3.9.12-final-0 -----------
Name                           Stmts   Miss  Cover
--------------------------------------------------
__init__.py                        0      0   100%
controllers/__init__.py          120      0   100%
db/__init__.py                     0      0   100%
db/models/__init__.py             61      0   100%
exceptions.py                      1      0   100%
main.py                          659     46    93%
managers/__init__.py               0      0   100%
managers/liveness_manager.py       7      7     0%
models.py                         13      0   100%
settings.py                        1      0   100%
--------------------------------------------------
TOTAL                            862     53    94%

====================================================================== 96 passed, 1366 warnings in 
lint run-test: commands[0] | python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished pylint
[isort] Skipped 4 files
:) No issues found.
________________________________________________________________________________________ summary _________________________________________________________________________________________
  py39: commands succeeded
  coverage: commands succeeded
  lint: commands succeeded
  congratulations :)

```