### PR TITLE
Send topology.switches and topology.links shallow copy on events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,8 @@ Removed
 
 Fixed
 =====
-- Send topology.switches and topology.links shallow copy on events ``kytos/topology.topology_loaded`` and ``kytos/topology.updated``
+- Send topology.switches and topology.links shallow copy on ``kytos/topology.topology_loaded`` and ``kytos/topology.updated`` events
+- Send object metadata shallow copy on ``kytos/topology.{entities}.metadata.{action}`` event
 
 Security
 ========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Removed
 
 Fixed
 =====
+- Send topology.switches and topology.links shallow copy on events ``kytos/topology.topology_loaded`` and ``kytos/topology.updated``
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def _get_topology(self):
         """Return an object representing the topology."""
-        return Topology(self.controller.switches, self.links)
+        return Topology(dict(self.controller.switches), dict(self.links))
 
     def _get_link_from_interface(self, interface):
         """Return the link of the interface, or None if it does not exist."""

--- a/main.py
+++ b/main.py
@@ -955,7 +955,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
         name = f'kytos/topology.{entities}.metadata.{action}'
         event = KytosEvent(name=name, content={entity: obj,
-                                               'metadata': obj.metadata})
+                                               'metadata': dict(obj.metadata)})
         self.controller.buffers.app.put(event)
         log.debug(f'Metadata from {obj.id} was {action}.')
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1390,7 +1390,7 @@ class TestMain(TestCase):
         count = 0
         for spec in [Switch, Interface, Link]:
             mock_obj = create_autospec(spec)
-            mock_obj.metadata = "A"
+            mock_obj.metadata = {"some_key": "some_value"}
             self.napp.notify_metadata_changes(mock_obj, 'added')
             self.assertEqual(mock_event.call_count, count+1)
             self.assertEqual(mock_buffers_put.call_count, count+1)


### PR DESCRIPTION
Fixes https://github.com/kytos-ng/pathfinder/issues/24

Send topology.switches and topology.links shallow copy on events:
- kytos/topology.topology_loaded
- kytos/topology.updated

I've also updated `kytos/topology.{entities}.metadata.{action}` to end a shallow copy, otherwise [on pathfinder](https://github.com/kytos-ng/pathfinder/blob/master/main.py#L217) it could result in issues too

Thanks for catching this @italovalcy, in the future, let's augment our docs with more best practices for this type of issue for developers who are creating/maintaining events.