### PR TITLE
Upgrade core development dependencies

### DIFF
--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -1,5 +1,5 @@
 """DB models."""
-# pylint: disable=unused-argument,no-self-use,no-self-argument,invalid-name,
+# pylint: disable=unused-argument,no-self-argument,invalid-name,
 # pylint: disable=no-name-in-module
 
 from datetime import datetime

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,5 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
 -e git+https://github.com/kytos-ng/kytos.git#egg=kytos
 -e .[dev]
+pytest-asyncio==0.18.3
 black==22.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in
@@ -12,14 +12,26 @@
     # via
     #   -r requirements/dev.in
     #   kytos
+asgiref==3.5.2
+    # via
+    #   flask
+    #   kytos
 astroid==2.9.3
     # via pylint
+asttokens==2.0.8
+    # via
+    #   kytos
+    #   stack-data
 attrs==21.4.0
     # via pytest
 backcall==0.1.0
     # via
     #   ipython
     #   kytos
+bidict==0.22.0
+    # via
+    #   kytos
+    #   python-socketio
 black==22.3.0
     # via -r requirements/dev.in
 blinker==1.4
@@ -30,7 +42,7 @@ certifi==2021.10.8
     # via
     #   elastic-apm
     #   kytos
-click==8.0.3
+click==8.1.3
     # via
     #   black
     #   flask
@@ -42,53 +54,56 @@ decorator==4.4.2
     # via
     #   ipython
     #   kytos
-    #   traitlets
 distlib==0.3.4
     # via virtualenv
 docopt==0.6.2
     # via yala
-docutils==0.18.1
+docutils==0.19
     # via
     #   kytos
     #   python-daemon
 elastic-apm[flask]==6.9.1
     # via kytos
+executing==1.0.0
+    # via
+    #   kytos
+    #   stack-data
 filelock==3.4.1
     # via
     #   tox
     #   virtualenv
-flask==1.1.2
+flask[async]==2.1.3
     # via
     #   flask-cors
     #   flask-socketio
     #   kytos
-flask-cors==3.0.8
+flask-cors==3.0.10
     # via kytos
-flask-socketio==4.2.1
+flask-socketio==5.2.0
     # via kytos
+importlib-metadata==4.12.0
+    # via
+    #   flask
+    #   kytos
 iniconfig==1.1.1
     # via pytest
-ipython==7.13.0
+ipython==8.1.1
     # via kytos
-ipython-genutils==0.2.0
-    # via
-    #   kytos
-    #   traitlets
 isort==5.10.1
     # via
     #   pylint
     #   yala
-itsdangerous==1.1.0
+itsdangerous==2.1.2
     # via
     #   flask
     #   kytos
-janus==0.4.0
+janus==1.0.0
     # via kytos
 jedi==0.16.0
     # via
     #   ipython
     #   kytos
-jinja2==2.11.1
+jinja2==3.1.2
     # via
     #   flask
     #   kytos
@@ -98,9 +113,13 @@ lockfile==0.12.2
     # via
     #   kytos
     #   python-daemon
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via
     #   jinja2
+    #   kytos
+matplotlib-inline==0.1.6
+    # via
+    #   ipython
     #   kytos
 mccabe==0.6.1
     # via pylint
@@ -116,10 +135,6 @@ parso==0.6.2
     #   kytos
 pathspec==0.9.0
     # via black
-pathtools==0.1.2
-    # via
-    #   kytos
-    #   watchdog
 pep517==0.12.0
     # via pip-tools
 pexpect==4.8.0
@@ -149,6 +164,10 @@ ptyprocess==0.6.0
     # via
     #   kytos
     #   pexpect
+pure-eval==0.2.2
+    # via
+    #   kytos
+    #   stack-data
 py==1.11.0
     # via
     #   pytest
@@ -157,11 +176,11 @@ pycodestyle==2.8.0
     # via yala
 pydantic==1.9.0
     # via kytos
-pygments==2.11.2
+pygments==2.13.0
     # via
     #   ipython
     #   kytos
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via kytos
 pylint==2.12.2
     # via yala
@@ -172,28 +191,33 @@ pyparsing==3.0.6
 pytest==7.0.0
     # via
     #   kytos-topology
+    #   pytest-asyncio
     #   pytest-cov
+pytest-asyncio==0.18.3
+    # via -r requirements/dev.in
 pytest-cov==3.0.0
     # via kytos-topology
-python-daemon==2.2.4
+python-daemon==2.3.1
     # via kytos
-python-engineio==3.12.1
+python-engineio==4.3.4
     # via
     #   kytos
     #   python-socketio
-python-socketio==4.5.1
+python-socketio==5.7.1
     # via
     #   flask-socketio
     #   kytos
 six==1.16.0
     # via
+    #   asttokens
     #   flask-cors
     #   kytos
-    #   python-engineio
-    #   python-socketio
     #   tox
-    #   traitlets
     #   virtualenv
+stack-data==0.5.0
+    # via
+    #   ipython
+    #   kytos
 tenacity==8.0.1
     # via kytos
 toml==0.10.2
@@ -208,14 +232,16 @@ tomli==1.2.3
     #   pytest
 tox==3.24.5
     # via kytos-topology
-traitlets==4.3.3
+traitlets==5.3.0
     # via
     #   ipython
     #   kytos
-typing-extensions==4.0.1
+    #   matplotlib-inline
+typing-extensions>=4.0.1
     # via
     #   astroid
     #   black
+    #   janus
     #   kytos
     #   pydantic
     #   pylint
@@ -225,13 +251,13 @@ urllib3==1.26.7
     #   kytos
 virtualenv==20.13.0
     # via tox
-watchdog==0.10.2
+watchdog==2.1.9
     # via kytos
 wcwidth==0.1.9
     # via
     #   kytos
     #   prompt-toolkit
-werkzeug==1.0.1
+werkzeug==2.0.3
     # via
     #   flask
     #   kytos
@@ -241,6 +267,10 @@ wrapt==1.13.3
     # via astroid
 yala==3.1.0
     # via kytos-topology
+zipp==3.8.1
+    # via
+    #   importlib-metadata
+    #   kytos
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ asgiref==3.5.2
     # via
     #   flask
     #   kytos
-astroid==2.9.3
+astroid==2.12.9
     # via pylint
 asttokens==2.0.8
     # via
@@ -54,6 +54,8 @@ decorator==4.4.2
     # via
     #   ipython
     #   kytos
+dill==0.3.4
+    # via pylint
 distlib==0.3.4
     # via virtualenv
 docopt==0.6.2
@@ -182,7 +184,7 @@ pygments==2.13.0
     #   kytos
 pyjwt==2.4.0
     # via kytos
-pylint==2.12.2
+pylint==2.15.0
     # via yala
 pymongo==4.1.0
     # via kytos
@@ -221,15 +223,16 @@ stack-data==0.5.0
 tenacity==8.0.1
     # via kytos
 toml==0.10.2
-    # via
-    #   pylint
-    #   tox
+    # via tox
 tomli==1.2.3
     # via
     #   black
     #   coverage
     #   pep517
+    #   pylint
     #   pytest
+tomlkit==0.11.4
+    # via pylint
 tox==3.24.5
     # via kytos-topology
 traitlets==5.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest conftest."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ev_loop(monkeypatch, event_loop) -> None:
+    """asyncio event loop autouse fixture."""
+    monkeypatch.setattr("asyncio.get_running_loop", lambda: event_loop)
+    yield event_loop

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock, patch, MagicMock
 
 # pylint: disable=import-error,no-name-in-module
 from kytos.core.events import KytosEvent
-from tests.integration.helpers import (get_controller_mock, get_interface_mock,
-                                       get_switch_mock)
+from kytos.lib.helpers import get_controller_mock
+from tests.integration.helpers import (get_interface_mock, get_switch_mock)
 
 LINK_DATA = {
     "active": False,

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,16 +1,4 @@
 """Module to help to create tests."""
-from unittest.mock import Mock
-
-from kytos.core import Controller
-from kytos.core.config import KytosConfig
-
-
-def get_controller_mock():
-    """Return a controller mock."""
-    options = KytosConfig().options['daemon']
-    controller = Controller(options)
-    controller.log = Mock()
-    return controller
 
 
 def get_napp_urls(napp):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -12,9 +12,10 @@ from kytos.core.interface import Interface
 from kytos.core.link import Link
 from kytos.core.switch import Switch
 from kytos.lib.helpers import (get_interface_mock, get_link_mock,
-                               get_switch_mock, get_test_client)
+                               get_controller_mock, get_switch_mock,
+                               get_test_client)
 from napps.kytos.topology.exceptions import RestoreError
-from tests.unit.helpers import get_controller_mock, get_napp_urls
+from tests.unit.helpers import get_napp_urls
 
 
 @pytest.mark.parametrize("liveness_status, status",


### PR DESCRIPTION
- Ugraded core dev dependencies (they needed to be regenerated). It's related to https://github.com/kytos-ng/kytos/pull/284. 
- I've also upgraded `pylint` and fixed linter errors that showed up. 
- For now, `feature/upgrade_dependencies` kytos branch is pinned just so tests pass in the CI. I'll revert this after before this PR gets merged after review. 