### PR TITLE
[Feature] Added event to publish the current topology when requested

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,11 @@ All notable changes to the ``topology`` project will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
+
 Added
 =====
+- Publish event ``kytos/topology.current`` for topology reconciliation
+- Subscribed to event ``kytos/topology.get`` to publish the current topology
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Subscribed
 - ``kytos/maintenance.end_switch``
 - ``kytos/.*.liveness.(up|down)``
 - ``kytos/.*.liveness.disabled``
+- ``kytos/topology.get``
 
 
 Published
@@ -88,6 +89,20 @@ kytos/topology.updated
 
 Event reporting that the topology was updated. It contains the most updated
 topology.
+
+Content:
+
+.. code-block:: python3
+
+   {
+     'topology': <Topology object>
+   }
+
+kytos/topology.current
+~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting the current topology, this is meant as a broadcast response when
+a subscriber needs it for reconciliation.
 
 Content:
 

--- a/main.py
+++ b/main.py
@@ -546,7 +546,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.controller.buffers.app.put(event)
 
     @listen_to("kytos/topology.get")
-    def on_get_topology(self, event) -> None:
+    def on_get_topology(self, _event) -> None:
+        """Handle kytos/topology.get."""
         self.notify_current_topology()
 
     @listen_to("kytos/.*.liveness.(up|down)")

--- a/main.py
+++ b/main.py
@@ -538,6 +538,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_metadata_changes(link, 'removed')
         return jsonify("Operation successful"), 200
 
+    def notify_current_topology(self) -> None:
+        """Notify current topology."""
+        name = "kytos/topology.current"
+        event = KytosEvent(name=name, content={"topology":
+                                               self._get_topology()})
+        self.controller.buffers.app.put(event)
+
+    @listen_to("kytos/topology.get")
+    def on_get_topology(self, event) -> None:
+        self.notify_current_topology()
+
     @listen_to("kytos/.*.liveness.(up|down)")
     def on_link_liveness_status(self, event) -> None:
         """Handle link liveness up|down status event."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -143,6 +143,7 @@ class TestMain(TestCase):
                            'kytos/.*.link_available_tags',
                            'kytos/.*.liveness.(up|down)',
                            'kytos/.*.liveness.disabled',
+                           'kytos/topology.get',
                            '.*.topo_controller.upsert_switch',
                            '.*.of_lldp.network_status.updated',
                            '.*.interface.is.nni',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,7 +7,6 @@ import time
 from unittest import TestCase
 from unittest.mock import MagicMock, create_autospec, patch
 
-from kytos.core import KytosEvent
 from kytos.core.common import EntityStatus
 from kytos.core.interface import Interface
 from kytos.core.link import Link


### PR DESCRIPTION

This is for helping out to fix this current issue that was caught on e2e tests, it'll provide a way to get and publish the current topology for reconciliation, although this doesn't fix the root cause it'll provide a recovery mechanism, and if it keeps happening with better instrumentation/logs on pathfinder we'll be able to catch (race conditions weren't spotted yet):

https://github.com/amlight/kytos-end-to-end-tests/issues/179

### Changelog

- Publish event ``kytos/topology.current`` for topology reconciliation
- Subscribed to event ``kytos/topology.get`` to publish the current topology
