### PR TITLE
[Fix] Load interfaces as inactive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Removed
 Fixed
 =====
 - Fixed link up to only notify when ``LINK_UP_TIMER`` has passed
+- Load interfaces as inactive
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -189,6 +189,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 interface.disable()
             interface.lldp = iface_att['lldp']
             interface.extend_metadata(iface_att["metadata"])
+            interface.deactivate()
             name = 'kytos/topology.port.created'
             event = KytosEvent(name=name, content={
                                               'switch': switch_id,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -362,6 +362,7 @@ class TestMain(TestCase):
             'interfaces': {
                 iface_a: {
                     'enabled': True,
+                    'active': True,
                     'lldp': True,
                     'id': iface_a,
                     'switch': dpid_a,
@@ -397,6 +398,7 @@ class TestMain(TestCase):
         self.assertEqual(interface.switch.id, dpid_a)
         self.assertEqual(interface.port_number, 1)
         self.assertTrue(interface.is_enabled())
+        self.assertFalse(interface.is_active())
         self.assertTrue(interface.lldp)
         self.assertTrue(interface.uni)
         self.assertFalse(interface.nni)


### PR DESCRIPTION
Fixes #113 

- Load interfaces as inactive

This PR is on top of #114 and it should be merged after Aldo's PR #115 (to facilitate merging things in order)

### Local tests

I've explored it simulating the original issues, and with mef_eline and link liveness enabled. It behaved as expected, since interfaces are initially loaded as inactive, they only will turn into active when handling port description or port status (when handling port description I found another issue though https://github.com/kytos-ng/of_core/issues/89):

Here's the topology output with the interfaces disabled when the topology gets loaded:

```
{
    "topology": {
        "links": {
            "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260": {
                "active": false,
                "enabled": true,
                "endpoint_a": {
                    "active": false,
                    ...
        },
        "switches": {
            "00:00:00:00:00:00:00:01": {
                "active": false,
                "connection": "",
                "data_path": "s1",
                "dpid": "00:00:00:00:00:00:00:01",
                "enabled": true,
                "hardware": "Open vSwitch",
                "id": "00:00:00:00:00:00:00:01",
                "interfaces": {
                    "00:00:00:00:00:00:00:01:1": {
                        "active": false,
                        "enabled": true,
                        "id": "00:00:00:00:00:00:00:01:1",
                        "link": "",
                        "lldp": true,
                        "mac": "12:39:a8:f9:11:b9",
                        "metadata": {},
                        "name": "s1-eth1",
                        "nni": false,
                        "port_number": 1,
                        "speed": 1250000000.0,
                        "switch": "00:00:00:00:00:00:00:01",
                        "type": "interface",
                        "uni": true
                    },
                    "00:00:00:00:00:00:00:01:2": {
                        "active": false,
                        "enabled": true,
                        ...
```

Liveness init state as expected as well:

```
{
    "interfaces": [
        {
            "id": "00:00:00:00:00:00:00:01:2",
            "last_hello_at": null,
            "status": "init"
        },
        {
            "id": "00:00:00:00:00:00:00:02:2",
            "last_hello_at": null,
            "status": "init"
        },
        {
            "id": "00:00:00:00:00:00:00:02:3",
            "last_hello_at": null,
            "status": "init"
        },
        {
            "id": "00:00:00:00:00:00:00:03:2",
            "last_hello_at": null,
            "status": "init"
        }
    ]
}
```

Once the switch connects again and send port description the states are as expected:

```
{
    "interfaces": [
        {
            "id": "00:00:00:00:00:00:00:01:2",
            "last_hello_at": "2022-11-30T16:40:29",
            "status": "up"
        },
        {
            "id": "00:00:00:00:00:00:00:02:2",
            "last_hello_at": "2022-11-30T16:40:29",
            "status": "up"
        },
        {
            "id": "00:00:00:00:00:00:00:02:3",
            "last_hello_at": "2022-11-30T16:40:29",
            "status": "up"
        },
        {
            "id": "00:00:00:00:00:00:00:03:2",
            "last_hello_at": "2022-11-30T16:40:29",
            "status": "up"
        }
    ]
}
```

```
{
    "topology": {
        "links": {
            "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260": {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:01:2",
                    "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
                    ...
        },
        "switches": {
            "00:00:00:00:00:00:00:01": {
                "active": true,
                "connection": "127.0.0.1:42036",
                "data_path": "s1",
                "dpid": "00:00:00:00:00:00:00:01",
                "enabled": true,
                "hardware": "Open vSwitch",
                "id": "00:00:00:00:00:00:00:01",
                "interfaces": {
                    "00:00:00:00:00:00:00:01:1": {
                        "active": true,
                        "enabled": true,
                        "id": "00:00:00:00:00:00:00:01:1",
                        "link": "",
                        "lldp": true,
                        "mac": "12:da:54:64:fe:5b",
                        "metadata": {},
                        "name": "s1-eth1",
                        "nni": false,
                        "port_number": 1,
                        "speed": 1250000000.0,
                        "switch": "00:00:00:00:00:00:00:01",
                        "type": "interface",
                        "uni": true
                    },
                    "00:00:00:00:00:00:00:01:2": {
                        "active": true,
                        "enabled": true,
                        "id": "00:00:00:00:00:00:00:01:2",
                        "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
                        "lldp": true,
                        ...
```

