### PR TITLE
[Fix] `handle_interface_created` should only activate if interface is active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed
 =====
 - Fixed link up to only notify when ``LINK_UP_TIMER`` has passed
 - Load interfaces as inactive
+- Created interface should only be activated if it's active
 
 Security
 ========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 - Fixed link up to only notify when ``LINK_UP_TIMER`` has passed
 - Load interfaces as inactive
 - Created interface should only be activated if it's active
+- Fixed last_status_is_active when both interfaces go down to notify only once
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -696,6 +696,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         created event again and it can be belong to a link.
         """
         interface = event.content['interface']
+        if not interface.is_active():
+            return
         self.handle_interface_link_up(interface)
 
     @listen_to('.*.topology.switch.interface.created')

--- a/main.py
+++ b/main.py
@@ -864,16 +864,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if link and not link.is_active():
             with self._links_lock:
                 last_status = link.get_metadata('last_status_is_active')
-                last_status_change = link.get_metadata('last_status_change')
+                last_status_change = time.time()
+                last_status_is_active = False
                 metadata = {
                     "last_status_change": last_status_change,
-                    "last_status_is_active": last_status,
+                    "last_status_is_active": last_status_is_active,
                 }
                 if last_status:
                     link.extend_metadata(metadata)
                     self.topo_controller.deactivate_link(link.id,
                                                          last_status_change,
-                                                         last_status)
+                                                         last_status_is_active)
                     self.notify_link_status_change(link, reason='link down')
         interface.deactivate()
         self.topo_controller.deactivate_interface(interface.id)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1173,6 +1173,17 @@ class TestMain(TestCase):
         self.napp.handle_interface_created(mock_event)
         mock_link_up.assert_called()
 
+    @patch('napps.kytos.topology.main.Main.handle_interface_link_up')
+    def test_handle_interface_created_inactive(self, mock_link_up):
+        """Test handle_interface_created inactive."""
+        mock_event = MagicMock()
+        mock_interface = create_autospec(Interface)
+        mock_interface.id = "1"
+        mock_event.content = {'interface': mock_interface}
+        mock_interface.is_active.return_value = False
+        self.napp.handle_interface_created(mock_event)
+        mock_link_up.assert_not_called()
+
     def test_handle_interfaces_created(self):
         """Test handle_interfaces_created."""
         buffers_app_mock = MagicMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1305,6 +1305,29 @@ class TestMain(TestCase):
         assert self.napp.topo_controller.deactivate_interface.call_count == 1
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
+    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
+    def test_handle_link_down_not_active_last_status(self, *args):
+        """Test interface link down with link not active."""
+        (mock_status_change, mock_topology_update,
+         mock_link_from_interface) = args
+
+        mock_interface = create_autospec(Interface)
+        mock_link = create_autospec(Link)
+        mock_link.is_active.return_value = False
+        mock_link_from_interface.return_value = mock_link
+        mock_link.get_metadata.return_value = True
+        self.napp.handle_link_down(mock_interface)
+        deactivate_link = self.napp.topo_controller.deactivate_link
+        assert deactivate_link.call_count == 1
+        assert deactivate_link.call_args[0][0] == mock_link.id
+        assert not deactivate_link.call_args[0][2]
+        mock_interface.deactivate.assert_called()
+        mock_topology_update.assert_called()
+        mock_status_change.assert_called()
+        assert self.napp.topo_controller.deactivate_interface.call_count == 1
+
+    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_link_up_if_status')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     def test_handle_link_up(self, *args):


### PR DESCRIPTION
This is related to https://github.com/kytos-ng/of_core/pull/90, 

It turns out that the event of interface creation was also assuming that the interface being created was active:

- Created interface should only be activated if it's active
- Fixed last_status_is_active when both interfaces go down to notify only once

Local tests were explored in the PR linked. 