### PR TITLE
Maintenance compatibility update

### DIFF
--- a/main.py
+++ b/main.py
@@ -1006,9 +1006,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Deals with the start of links maintenance."""
         notify_links = []
         maintenance_links = event.content['links']
-        for maintenance_link in maintenance_links:
+        for maintenance_link_id in maintenance_links:
             try:
-                link = self.links[maintenance_link.id]
+                link = self.links[maintenance_link_id]
             except KeyError:
                 continue
             notify_links.append(link)
@@ -1031,9 +1031,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Deals with the end of links maintenance."""
         notify_links = []
         maintenance_links = event.content['links']
-        for maintenance_link in maintenance_links:
+        for maintenance_link_id in maintenance_links:
             try:
-                link = self.links[maintenance_link.id]
+                link = self.links[maintenance_link_id]
             except KeyError:
                 continue
             notify_links.append(link)

--- a/main.py
+++ b/main.py
@@ -729,7 +729,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_switch_maintenance_end(self, event):
         """Handle the end of the maintenance of a switch."""
         switches = event.content['switches']
-        for switch in switches:
+        for switch_id in switches:
+            try:
+                switch = self.controller.switches[switch_id]
+            except KeyError:
+                continue
             switch.enable()
             switch.activate()
             for interface in switch.interfaces.values():
@@ -800,7 +804,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_switch_maintenance_start(self, event):
         """Handle the start of the maintenance of a switch."""
         switches = event.content['switches']
-        for switch in switches:
+        for switch_id in switches:
+            try:
+                switch = self.controller.switches[switch_id]
+            except KeyError:
+                continue
             switch.disable()
             switch.deactivate()
             for interface in switch.interfaces.values():

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1457,7 +1457,7 @@ class TestMain(TestCase):
         link2.id = 3
         link3 = MagicMock()
         link3.id = 4
-        content = {'links': [link1, link2]}
+        content = {'links': [link1.id, link2.id]}
         event = MagicMock()
         event.content = content
         self.napp.links = {2: link1, 4: link3}
@@ -1473,7 +1473,7 @@ class TestMain(TestCase):
         link2.id = 3
         link3 = MagicMock()
         link3.id = 4
-        content = {'links': [link1, link2]}
+        content = {'links': [link1.id, link2.id]}
         event = MagicMock()
         event.content = content
         self.napp.links = {2: link1, 4: link3}
@@ -1484,6 +1484,7 @@ class TestMain(TestCase):
     def test_handle_switch_maintenance_start(self, handle_link_down_mock):
         """Test handle_switch_maintenance_start."""
         switch1 = MagicMock()
+        switch1.id = 'a'
         interface1 = MagicMock()
         interface1.is_active.return_value = True
         interface2 = MagicMock()
@@ -1492,14 +1493,16 @@ class TestMain(TestCase):
         interface3.is_active.return_value = True
         switch1.interfaces = {1: interface1, 2: interface2, 3: interface3}
         switch2 = MagicMock()
+        switch2.id = 'b'
         interface4 = MagicMock()
         interface4.is_active.return_value = False
         interface5 = MagicMock()
         interface5.is_active.return_value = True
         switch2.interfaces = {1: interface4, 2: interface5}
-        content = {'switches': [switch1, switch2]}
+        content = {'switches': [switch1.id, switch2.id]}
         event = MagicMock()
         event.content = content
+        self.napp.controller.switches = {'a': switch1, 'b': switch2}
         self.napp.handle_switch_maintenance_start(event)
         self.assertEqual(handle_link_down_mock.call_count, 3)
 
@@ -1507,6 +1510,7 @@ class TestMain(TestCase):
     def test_handle_switch_maintenance_end(self, handle_link_up_mock):
         """Test handle_switch_maintenance_end."""
         switch1 = MagicMock()
+        switch1.id = 'a'
         interface1 = MagicMock()
         interface1.is_active.return_value = True
         interface2 = MagicMock()
@@ -1515,13 +1519,15 @@ class TestMain(TestCase):
         interface3.is_active.return_value = True
         switch1.interfaces = {1: interface1, 2: interface2, 3: interface3}
         switch2 = MagicMock()
+        switch2.id = 'b'
         interface4 = MagicMock()
         interface4.is_active.return_value = False
         interface5 = MagicMock()
         interface5.is_active.return_value = True
         switch2.interfaces = {1: interface4, 2: interface5}
-        content = {'switches': [switch1, switch2]}
+        content = {'switches': [switch1.id, switch2.id]}
         event = MagicMock()
         event.content = content
+        self.napp.controller.switches = {'a': switch1, 'b': switch2}
         self.napp.handle_switch_maintenance_end(event)
         self.assertEqual(handle_link_up_mock.call_count, 5)


### PR DESCRIPTION
This PR is intended to provide compatibility with kytos-ng/maintenance#64, which updates the format of events for maintenance windows to use device ids. Should kytos-ng/maintenance#64 be accepted, this PR should be accepted along with it.