### PR TITLE
fix: rejected unordered late preempted interface events to avoid state inconsistencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Rejected unordered late preempted interface events to avoid state inconsistencies
+
 General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.

--- a/main.py
+++ b/main.py
@@ -43,6 +43,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
         self._links_lock = Lock()
         self._links_notify_lock = defaultdict(Lock)
+        # to keep track of potential unorded scheduled interface events
+        self._intfs_lock = defaultdict(Lock)
+        self._intfs_updated_at = {}
         self.topo_controller = self.get_topo_controller()
         Link.register_status_func(f"{self.napp_id}_link_up_timer",
                                   self.link_status_hook_link_up_timer)
@@ -707,7 +710,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface = event.content['interface']
         if not interface.is_active():
             return
-        self.handle_interface_link_up(interface)
+        self.handle_interface_link_up(interface, event)
 
     @listen_to('.*.topology.switch.interface.created')
     def on_interface_created(self, event):
@@ -731,7 +734,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface = event.content['interface']
         interface.deactivate()
         self.topo_controller.deactivate_interface(interface.id)
-        self.handle_interface_link_down(interface)
+        self.handle_interface_link_down(interface, event)
 
     @listen_to('.*.switch.interface.deleted')
     def on_interface_deleted(self, event):
@@ -749,10 +752,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         The event notifies that an interface's link was changed to 'up'.
         """
         interface = event.content['interface']
-        self.handle_interface_link_up(interface)
+        self.handle_interface_link_up(interface, event)
 
-    def handle_interface_link_up(self, interface):
+    def handle_interface_link_up(self, interface, event):
         """Update the topology based on a Port Modify event."""
+        with self._intfs_lock[interface.id]:
+            if (
+                interface.id in self._intfs_updated_at
+                and self._intfs_updated_at[interface.id] > event.timestamp
+            ):
+                return
+            self._intfs_updated_at[interface.id] = event.timestamp
         self.handle_link_up(interface)
 
     @listen_to('kytos/maintenance.end_switch')
@@ -837,10 +847,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         The event notifies that an interface's link was changed to 'down'.
         """
         interface = event.content['interface']
-        self.handle_interface_link_down(interface)
+        self.handle_interface_link_down(interface, event)
 
-    def handle_interface_link_down(self, interface):
+    def handle_interface_link_down(self, interface, event):
         """Update the topology based on an interface."""
+        with self._intfs_lock[interface.id]:
+            if (
+                interface.id in self._intfs_updated_at
+                and self._intfs_updated_at[interface.id] > event.timestamp
+            ):
+                return
+            self._intfs_updated_at[interface.id] = event.timestamp
         self.handle_link_down(interface)
 
     @listen_to('kytos/maintenance.start_switch')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1197,13 +1197,11 @@ class TestMain:
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interface_link_down_unordered_event(self, *args):
         """Test interface link down unordered event."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        (mock_status_change, mock_topology_update) = args
 
         mock_interface = create_autospec(Interface)
         mock_interface.id = "1"
@@ -1215,13 +1213,11 @@ class TestMain:
         mock_topology_update.assert_not_called()
         mock_status_change.assert_not_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interface_link_up_unordered_event(self, *args):
         """Test interface link up unordered event."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        (mock_status_change, mock_topology_update) = args
 
         mock_interface = create_autospec(Interface)
         mock_interface.id = "1"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1172,7 +1172,8 @@ class TestMain:
         mock_link.endpoint_b = mock_interface_b
         mock_link_from_interface.return_value = mock_link
         mock_link.status = EntityStatus.UP
-        self.napp.handle_interface_link_up(mock_interface_a)
+        event = KytosEvent("kytos.of_core.switch.interface.down")
+        self.napp.handle_interface_link_up(mock_interface_a, event)
         mock_notify_topology_update.assert_called()
         mock_link.extend_metadata.assert_called()
         mock_link.activate.assert_called()
@@ -1187,15 +1188,50 @@ class TestMain:
         (mock_status_change, mock_topology_update,
          mock_link_from_interface) = args
 
-        mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
         mock_link = create_autospec(Link)
         mock_link.is_active.return_value = True
         mock_link_from_interface.return_value = mock_link
-        mock_event.content['interface'] = mock_interface
-        self.napp.handle_interface_link_down(mock_event)
+        event = KytosEvent("kytos.of_core.switch.interface.link_up")
+        self.napp.handle_interface_link_down(mock_interface, event)
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
+
+    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
+    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
+    def test_interface_link_down_unordered_event(self, *args):
+        """Test interface link down unordered event."""
+        (mock_status_change, mock_topology_update,
+         mock_link_from_interface) = args
+
+        mock_interface = create_autospec(Interface)
+        mock_interface.id = "1"
+        event_2 = KytosEvent("kytos.of_core.switch.interface.down")
+        event_1 = KytosEvent("kytos.of_core.switch.interface.up")
+        assert event_1.timestamp > event_2.timestamp
+        self.napp._intfs_updated_at[mock_interface.id] = event_1.timestamp
+        self.napp.handle_interface_link_down(mock_interface, event_2)
+        mock_topology_update.assert_not_called()
+        mock_status_change.assert_not_called()
+
+    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
+    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
+    def test_interface_link_up_unordered_event(self, *args):
+        """Test interface link up unordered event."""
+        (mock_status_change, mock_topology_update,
+         mock_link_from_interface) = args
+
+        mock_interface = create_autospec(Interface)
+        mock_interface.id = "1"
+        event_2 = KytosEvent("kytos.of_core.switch.interface.up")
+        event_1 = KytosEvent("kytos.of_core.switch.interface.down")
+        assert event_1.timestamp > event_2.timestamp
+        self.napp._intfs_updated_at[mock_interface.id] = event_1.timestamp
+        self.napp.handle_interface_link_up(mock_interface, event_2)
+        mock_topology_update.assert_not_called()
+        mock_status_change.assert_not_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')


### PR DESCRIPTION
Closes https://github.com/kytos-ng/of_core/issues/118

This fixes a major issue that @italovalcy has hit during the prod deployment, so I ended up prioritizing this fix to avoid blocking the prod deployment. I'll send a PR backporting this shortly.

### Summary

- Rejected unordered late preempted interface events to avoid state inconsistencies
- Essentially, this fix is analogous to https://github.com/kytos-ng/pathfinder/pull/35/files. It turns out that we do have order guarantees from our core queues, but thread pool based handlers aka `@listen_to`, their threads can get preempted and based on non deterministic scheduling from threads you can end up in this case, this becomes more evident in cases where there's too many events, so whenever a shared resource like interface state is vulnerable to this unwanted behavior then we'll need safe guards. `asyncio` can also partly help to avoid problems like this in the first place, but it's still not a silver bullet, so for now, developers should always be aware of shared runtime state and where thread context switches can happen (or asyncio context yield can happen)

### Local Tests

I used script to simulate a link flap, 200 link flaps with `ip link set dev <intf> down|up` over 100 iterations, and always asserting that the link.status and ints endpoints were UP after each iteration, no inconsistencies were observed anymore:

```
link_flap test iteration 97
         waiting for 12 before next iteration
link_flap test iteration 98
         waiting for 12 before next iteration
link_flap test iteration 99
         waiting for 12 before next iteration
```

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

import time
import httpx
import subprocess


def do_link_flap(interfaces: list[str]) -> None:
    """perform link flap."""
    for intf in interfaces:
        subprocess.check_output(["sudo", "ip", "link", "set", "dev", intf, "down"])
    for intf in interfaces:
        subprocess.check_output(["sudo", "ip", "link", "set", "dev", intf, "up"])


def assert_topology_link_up(link_id: str) -> None:
    """assert link up."""
    client = httpx.Client(base_url="http://localhost:8181/api/kytos/topology/v3/links")
    resp = client.get("/")
    resp.raise_for_status()
    data = resp.json()
    link = data["links"][link_id]
    assert link["status"] == "UP", link
    assert link["endpoint_a"]["status"] == "UP", link
    assert link["endpoint_b"]["status"] == "UP", data


def main() -> None:
    """Main function."""
    link_flap_iters = 200
    interfaces = ["s1-eth4", "s1-eth4"]
    link_id = "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07"
    wait_for = 12
    test_iters = 100

    for test_iter in range(test_iters):
        print(f"link_flap test iteration {test_iter}")
        assert_topology_link_up(link_id)
        for i in range(link_flap_iters):
            do_link_flap(interfaces)
        print(f"\t waiting for {wait_for} before next iteration")
        time.sleep(wait_for)
        assert_topology_link_up(link_id)


if __name__ == "__main__":
    main()
```

### End-to-End Tests

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 26%]
tests/test_e2e_11_mef_eline.py ......                                    [ 29%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 32%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 50%]
...                                                                      [ 51%]
tests/test_e2e_14_mef_eline.py x                                         [ 52%]
tests/test_e2e_15_mef_eline.py ..                                        [ 53%]
tests/test_e2e_20_flow_manager.py .....................                  [ 62%]
tests/test_e2e_21_flow_manager.py ...                                    [ 63%]
tests/test_e2e_22_flow_manager.py ...............                        [ 70%]
tests/test_e2e_23_flow_manager.py ..............                         [ 76%]
tests/test_e2e_30_of_lldp.py ....                                        [ 78%]
tests/test_e2e_31_of_lldp.py ...                                         [ 79%]
tests/test_e2e_32_of_lldp.py ...                                         [ 81%]
tests/test_e2e_40_sdntrace.py ...........                                [ 85%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 89%]
tests/test_e2e_50_maintenance.py ........................                [100%]
=============================== warnings summary ===============================
= 205 passed, 6 skipped, 11 xfailed, 5 xpassed, 799 warnings in 10507.89s (2:55:07) =
```