### PR TITLE
[2022.3.1] fix: rejected unordered late preempted interface events to avoid state inconsistencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2023-05-13
+***********************
+
+Fixed
+=====
+- Rejected unordered late preempted interface events to avoid state inconsistencies
+
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1264,13 +1264,11 @@ class TestMain(TestCase):
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interface_link_down_unordered_event(self, *args):
         """Test interface link down unordered event."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        (mock_status_change, mock_topology_update) = args
 
         mock_interface = create_autospec(Interface)
         mock_interface.id = "1"
@@ -1282,13 +1280,11 @@ class TestMain(TestCase):
         mock_topology_update.assert_not_called()
         mock_status_change.assert_not_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interface_link_up_unordered_event(self, *args):
         """Test interface link up unordered event."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        (mock_status_change, mock_topology_update) = args
 
         mock_interface = create_autospec(Interface)
         mock_interface.id = "1"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1239,7 +1239,8 @@ class TestMain(TestCase):
         mock_link.endpoint_b = mock_interface_b
         mock_link_from_interface.return_value = mock_link
         mock_link.status = EntityStatus.UP
-        self.napp.handle_interface_link_up(mock_interface_a)
+        event = KytosEvent("kytos.of_core.switch.interface.down")
+        self.napp.handle_interface_link_up(mock_interface_a, event)
         mock_notify_topology_update.assert_called()
         mock_link.extend_metadata.assert_called()
         mock_link.activate.assert_called()
@@ -1254,15 +1255,50 @@ class TestMain(TestCase):
         (mock_status_change, mock_topology_update,
          mock_link_from_interface) = args
 
-        mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
         mock_link = create_autospec(Link)
         mock_link.is_active.return_value = True
         mock_link_from_interface.return_value = mock_link
-        mock_event.content['interface'] = mock_interface
-        self.napp.handle_interface_link_down(mock_event)
+        event = KytosEvent("kytos.of_core.switch.interface.link_up")
+        self.napp.handle_interface_link_down(mock_interface, event)
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
+
+    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
+    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
+    def test_interface_link_down_unordered_event(self, *args):
+        """Test interface link down unordered event."""
+        (mock_status_change, mock_topology_update,
+         mock_link_from_interface) = args
+
+        mock_interface = create_autospec(Interface)
+        mock_interface.id = "1"
+        event_2 = KytosEvent("kytos.of_core.switch.interface.down")
+        event_1 = KytosEvent("kytos.of_core.switch.interface.up")
+        assert event_1.timestamp > event_2.timestamp
+        self.napp._intfs_updated_at[mock_interface.id] = event_1.timestamp
+        self.napp.handle_interface_link_down(mock_interface, event_2)
+        mock_topology_update.assert_not_called()
+        mock_status_change.assert_not_called()
+
+    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
+    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
+    def test_interface_link_up_unordered_event(self, *args):
+        """Test interface link up unordered event."""
+        (mock_status_change, mock_topology_update,
+         mock_link_from_interface) = args
+
+        mock_interface = create_autospec(Interface)
+        mock_interface.id = "1"
+        event_2 = KytosEvent("kytos.of_core.switch.interface.up")
+        event_1 = KytosEvent("kytos.of_core.switch.interface.down")
+        assert event_1.timestamp > event_2.timestamp
+        self.napp._intfs_updated_at[mock_interface.id] = event_1.timestamp
+        self.napp.handle_interface_link_up(mock_interface, event_2)
+        mock_topology_update.assert_not_called()
+        mock_status_change.assert_not_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')


### PR DESCRIPTION
Backported from https://github.com/kytos-ng/topology/pull/132, the summary and local tests are the same and the other PR so check out there.

@italovalcy, let me know if you can try out this backported branch `fix/unordered_intf_events_backport_2022.3` in the next days. I've dispatched e2e for the other PR, but it should be the same expected result. Appreciated your help and good catch. Once this lands then we'll push a tag `2022.3.1` on top of `base/2022.3.1` branch that this PR is targeting. 