### PR TITLE
feat: updated Link liveness log message to include `link.id` too

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ All notable changes to the ``topology`` project will be documented in this file.
 Fixed
 =====
 - Rejected unordered late preempted interface events to avoid state inconsistencies
+- Updated Link liveness log message to also include ``link.id``
 
 General Information
 ===================

--- a/main.py
+++ b/main.py
@@ -588,7 +588,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_link_liveness_status(self, link, liveness_status) -> None:
         """Handle link liveness."""
         metadata = {"liveness_status": liveness_status}
-        log.info(f"Link liveness {liveness_status}: {link.id}")
+        log.info(f"Link liveness {liveness_status}: {link}, id: {link.id}")
         self.topo_controller.add_link_metadata(link.id, metadata)
         link.extend_metadata(metadata)
         self.notify_topology_update()

--- a/main.py
+++ b/main.py
@@ -588,7 +588,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_link_liveness_status(self, link, liveness_status) -> None:
         """Handle link liveness."""
         metadata = {"liveness_status": liveness_status}
-        log.info(f"Link liveness {liveness_status}: {link}")
+        log.info(f"Link liveness {liveness_status}: {link.id}")
         self.topo_controller.add_link_metadata(link.id, metadata)
         link.extend_metadata(metadata)
         self.notify_topology_update()


### PR DESCRIPTION
Closes #120 

### Summary

See updated changelog file

### Local Tests

- I enabled liveness, confirmed it went up with the expected message, and then also simulated liveness down:

```
2023-05-23 11:53:37,499 - INFO [kytos.napps.kytos/topology] (thread_pool_app_2) Link liveness up: Link(Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02'))), id: 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30
2023-05-23 11:53:37,506 - INFO [kytos.napps.kytos/topology] (thread_pool_app_0) Link liveness up: Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01'))), id: 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0
2023-05-23 11:53:37,513 - INFO [kytos.napps.kytos/topology] (thread_pool_app_14) Link liveness up: Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))), id: c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07

kytos $> 2023-05-23 11:57:16,981 - INFO [kytos.napps.kytos/topology] (thread_pool_app_0) Link liveness down: Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface(' s1-eth3', 3, Switch('00:00:00:00:00:00:00:01'))), id: 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0
2023-05-23 11:57:16,983 - INFO [kytos.napps.kytos/topology] (thread_pool_app_15) Link liveness down: Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))), id: c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07


```

### End-to-End Tests

Not needed, it's a trivial change.