### PR TITLE
fix: Fixed interface and link activation/deactivation race condition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,12 @@ All notable changes to the ``topology`` project will be documented in this file.
 
 Fixed
 =====
+- Fixed interface and link activation/deactivation race condition
 - Rejected unordered late preempted interface events to avoid state inconsistencies
+
+Changed
+=======
+- Stopped storing interface and link ``active`` field in the DB
 
 General Information
 ===================

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=invalid-name
 import os
-import time
 from datetime import datetime
 from threading import Lock
 from typing import List, Optional, Tuple
@@ -126,10 +125,6 @@ class TopoController:
         """Try to find one switch and enable it."""
         return self._update_switch(dpid, {"$set": {"enabled": True}})
 
-    def deactivate_switch(self, dpid: str) -> Optional[dict]:
-        """Try to find one switch and deactivate it."""
-        return self._update_switch(dpid, {"$set": {"active": False}})
-
     def disable_switch(self, dpid: str) -> Optional[dict]:
         """Try to find one switch and disable it."""
         return self._update_switch(
@@ -159,16 +154,6 @@ class TopoController:
         """Try to disable one interface and its embedded object on links."""
         return self._update_interface(
             interface_id, {"$set": {"enabled": False}}
-        )
-
-    def activate_interface(self, interface_id: str) -> Optional[dict]:
-        """Try to activate one interface."""
-        return self._update_interface(interface_id, {"$set": {"active": True}})
-
-    def deactivate_interface(self, interface_id: str) -> Optional[dict]:
-        """Try to deactivate one interface."""
-        return self._update_interface(
-            interface_id, {"$set": {"active": False}}
         )
 
     def add_interface_metadata(
@@ -263,42 +248,6 @@ class TopoController:
     def disable_link(self, link_id: str) -> Optional[dict]:
         """Try to find one link and disable it."""
         return self._update_link(link_id, {"$set": {"enabled": False}})
-
-    def deactivate_link(self, link_id: str,
-                        last_status_change: Optional[float] = None,
-                        last_status_is_active=False
-                        ) -> Optional[dict]:
-        """Try to find one link and deactivate it."""
-        # It might be worth using datetime in the future
-        last_status_change = last_status_change or time.time()
-        return self._update_link(
-            link_id,
-            {
-                "$set": {
-                    "metadata.last_status_change": last_status_change,
-                    "metadata.last_status_is_active": last_status_is_active,
-                    "active": False,
-                }
-            },
-        )
-
-    def activate_link(self, link_id: str,
-                      last_status_change: Optional[float] = None,
-                      last_status_is_active=True
-                      ) -> Optional[dict]:
-        """Try to find one link and activate it."""
-        # It might be worth using datetime in the future
-        last_status_change = last_status_change or time.time()
-        return self._update_link(
-            link_id,
-            {
-                "$set": {
-                    "metadata.last_status_change": last_status_change,
-                    "metadata.last_status_is_active": last_status_is_active,
-                    "active": True,
-                }
-            },
-        )
 
     def add_link_metadata(
         self, link_id: str, metadata: dict

--- a/main.py
+++ b/main.py
@@ -117,11 +117,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def _get_link_from_interface(self, interface):
         """Return the link of the interface, or None if it does not exist."""
-        with self._links_lock:
-            for link in self.links.values():
-                if interface in (link.endpoint_a, link.endpoint_b):
-                    return link
-            return None
+        for link in list(self.links.values()):
+            if interface in (link.endpoint_a, link.endpoint_b):
+                return link
+        return None
 
     def _load_link(self, link_att):
         endpoint_a = link_att['endpoint_a']['id']
@@ -144,6 +143,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.enable()
         else:
             link.disable()
+
+        # These ones are just runtime active southbound protocol data
+        # It won't be stored in the future, only kept in the runtime.
+        # Also network operators can follow logs to track this state changes
+        for key in (
+            "last_status_is_active", "last_status_change", "notified_up_at"
+        ):
+            link_att["metadata"].pop(key, None)
 
         link.extend_metadata(link_att["metadata"])
         interface_a.update_link(link)
@@ -685,7 +692,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         switch = event.content['source'].switch
         if switch:
             switch.deactivate()
-            self.topo_controller.deactivate_switch(switch.id)
             log.debug('Switch %s removed from the Topology.', switch.id)
             self.notify_topology_update()
 
@@ -732,8 +738,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         The event notifies that an interface was changed to 'down'.
         """
         interface = event.content['interface']
+        with self._intfs_lock[interface.id]:
+            if (
+                interface.id in self._intfs_updated_at
+                and self._intfs_updated_at[interface.id] > event.timestamp
+            ):
+                return
+            self._intfs_updated_at[interface.id] = event.timestamp
         interface.deactivate()
-        self.topo_controller.deactivate_interface(interface.id)
         self.handle_interface_link_down(interface, event)
 
     @listen_to('.*.switch.interface.deleted')
@@ -813,31 +825,29 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 return
             key, notified_at = "notified_up_at", now()
             link.update_metadata(key, now())
-            self.topo_controller.add_link_metadata(link.id, {key: notified_at})
             self.notify_topology_update()
             self.notify_link_status_change(link, reason)
 
     def handle_link_up(self, interface):
         """Handle link up for an interface."""
-        interface.activate()
-        self.topo_controller.activate_interface(interface.id)
-        self.notify_topology_update()
-        link = self._get_link_from_interface(interface)
-        if not link:
-            return
-        if link.endpoint_a == interface:
-            other_interface = link.endpoint_b
-        else:
-            other_interface = link.endpoint_a
-        if other_interface.is_active() is False:
-            return
-        metadata = {
-            'last_status_change': time.time(),
-            'last_status_is_active': True
-        }
-        link.extend_metadata(metadata)
-        link.activate()
-        self.topo_controller.activate_link(link.id, **metadata)
+        with self._links_lock:
+            link = self._get_link_from_interface(interface)
+            if not link:
+                self.notify_topology_update()
+                return
+            other_interface = (
+                link.endpoint_b if link.endpoint_a == interface
+                else link.endpoint_a
+            )
+            if other_interface.is_active() is False:
+                return
+            metadata = {
+                'last_status_change': time.time(),
+                'last_status_is_active': True
+            }
+            link.extend_metadata(metadata)
+            link.activate()
+            self.notify_topology_update()
         self.notify_link_up_if_status(link, "link up")
 
     @listen_to('.*.switch.interface.link_down')
@@ -882,37 +892,19 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def handle_link_down(self, interface):
         """Notify a link is down."""
-        link = self._get_link_from_interface(interface)
-        if link and link.is_active():
+        with self._links_lock:
+            link = self._get_link_from_interface(interface)
+            if not link or not link.get_metadata("last_status_is_active"):
+                self.notify_topology_update()
+                return
             link.deactivate()
-            last_status_change = time.time()
-            last_status_is_active = False
             metadata = {
-                "last_status_change": last_status_change,
-                "last_status_is_active": last_status_is_active,
+                "last_status_change": time.time(),
+                "last_status_is_active": False,
             }
             link.extend_metadata(metadata)
-            self.topo_controller.deactivate_link(link.id, last_status_change,
-                                                 last_status_is_active)
             self.notify_link_status_change(link, reason="link down")
-        if link and not link.is_active():
-            with self._links_lock:
-                last_status = link.get_metadata('last_status_is_active')
-                last_status_change = time.time()
-                last_status_is_active = False
-                metadata = {
-                    "last_status_change": last_status_change,
-                    "last_status_is_active": last_status_is_active,
-                }
-                if last_status:
-                    link.extend_metadata(metadata)
-                    self.topo_controller.deactivate_link(link.id,
-                                                         last_status_change,
-                                                         last_status_is_active)
-                    self.notify_link_status_change(link, reason='link down')
-        interface.deactivate()
-        self.topo_controller.deactivate_interface(interface.id)
-        self.notify_topology_update()
+            self.notify_topology_update()
 
     @listen_to('.*.interface.is.nni')
     def on_add_links(self, event):

--- a/main.py
+++ b/main.py
@@ -840,6 +840,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 else link.endpoint_a
             )
             if other_interface.is_active() is False:
+                self.notify_topology_update()
                 return
             metadata = {
                 'last_status_change': time.time(),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1177,7 +1177,6 @@ class TestMain:
         mock_notify_topology_update.assert_called()
         mock_link.extend_metadata.assert_called()
         mock_link.activate.assert_called()
-        self.napp.topo_controller.activate_link.assert_called()
         mock_notify_link_up_if_status.assert_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
@@ -1242,12 +1241,11 @@ class TestMain:
         mock_link.is_active.return_value = True
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_down(mock_interface)
-        assert self.napp.topo_controller.deactivate_link.call_count == 1
-        mock_interface.deactivate.assert_called()
+        mock_interface.deactivate.assert_not_called()
         mock_link.deactivate.assert_called()
+        mock_link.extend_metadata.assert_called()
         assert mock_topology_update.call_count == 1
         mock_status_change.assert_called()
-        assert self.napp.topo_controller.deactivate_interface.call_count == 1
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
@@ -1263,11 +1261,8 @@ class TestMain:
         mock_link_from_interface.return_value = mock_link
         mock_link.get_metadata.return_value = False
         self.napp.handle_link_down(mock_interface)
-        assert self.napp.topo_controller.deactivate_link.call_count == 0
-        mock_interface.deactivate.assert_called()
         mock_topology_update.assert_called()
         mock_status_change.assert_not_called()
-        assert self.napp.topo_controller.deactivate_interface.call_count == 1
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
@@ -1283,14 +1278,8 @@ class TestMain:
         mock_link_from_interface.return_value = mock_link
         mock_link.get_metadata.return_value = True
         self.napp.handle_link_down(mock_interface)
-        deactivate_link = self.napp.topo_controller.deactivate_link
-        assert deactivate_link.call_count == 1
-        assert deactivate_link.call_args[0][0] == mock_link.id
-        assert not deactivate_link.call_args[0][2]
-        mock_interface.deactivate.assert_called()
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
-        assert self.napp.topo_controller.deactivate_interface.call_count == 1
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_link_up_if_status')
@@ -1306,8 +1295,7 @@ class TestMain:
         mock_link.is_active.return_value = True
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_up(mock_interface)
-        assert self.napp.topo_controller.activate_link.call_count == 1
-        mock_interface.activate.assert_called()
+        mock_interface.activate.assert_not_called()
         assert mock_notify_link_up_if_status.call_count == 1
         mock_notify_topology_update.assert_called()
 
@@ -1326,8 +1314,7 @@ class TestMain:
         mock_link.is_active.return_value = False
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_up(mock_interface)
-        mock_interface.activate.assert_called()
-        assert self.napp.topo_controller.activate_link.call_count == 0
+        mock_interface.activate.assert_not_called()
         assert mock_topology_update.call_count == 1
         mock_status_change.assert_not_called()
 
@@ -1579,7 +1566,6 @@ class TestMain:
         link.get_metadata.return_value = now() - timedelta(seconds=60)
         assert not self.napp.notify_link_up_if_status(link, "link up")
         link.update_metadata.assert_called()
-        self.napp.topo_controller.add_link_metadata.assert_called()
         mock_notify_topo.assert_called()
         mock_notify_link.assert_called()
 

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -88,15 +88,6 @@ class TestTopoController(TestCase):  # pylint: disable=too-many-public-methods
         assert arg1 == {"_id": self.dpid}
         assert not arg2["$set"]["enabled"]
 
-    def test_deactivate_switch(self) -> None:
-        """test_deactivate_switch."""
-        self.topo.deactivate_switch(self.dpid)
-
-        self.topo.db.switches.find_one_and_update.assert_called()
-        arg1, arg2 = self.topo.db.switches.find_one_and_update.call_args[0]
-        assert arg1 == {"_id": self.dpid}
-        assert not arg2["$set"]["active"]
-
     def test_add_switch_metadata(self) -> None:
         """test_add_switch_metadata."""
         metadata = {"some": "value"}
@@ -134,58 +125,6 @@ class TestTopoController(TestCase):  # pylint: disable=too-many-public-methods
         arg1, arg2 = self.topo.db.switches.find_one_and_update.call_args[0]
         assert arg1 == {"interfaces.id": self.interface_id}
         assert not arg2["$set"]["interfaces.$.enabled"]
-
-    def test_activate_interface(self) -> None:
-        """test_activate_interface."""
-        self.topo.activate_interface(self.interface_id)
-
-        self.topo.db.switches.find_one_and_update.assert_called()
-        arg1, arg2 = self.topo.db.switches.find_one_and_update.call_args[0]
-        assert arg1 == {"interfaces.id": self.interface_id}
-        assert arg2["$set"]["interfaces.$.active"]
-
-    def test_deactivate_interface(self) -> None:
-        """test_deactivate_interface."""
-        self.topo.deactivate_interface(self.interface_id)
-
-        self.topo.db.switches.find_one_and_update.assert_called()
-        arg1, arg2 = self.topo.db.switches.find_one_and_update.call_args[0]
-        assert arg1 == {"interfaces.id": self.interface_id}
-        assert not arg2["$set"]["interfaces.$.active"]
-
-    def test_activate_link(self) -> None:
-        """test activate_link."""
-        mock = MagicMock()
-        self.topo._update_link = mock
-        self.topo.activate_link(self.link_id, last_status_change=1,
-                                last_status_is_active=True)
-        self.topo._update_link.assert_called_with(
-            self.link_id,
-            {
-                "$set": {
-                    "metadata.last_status_change": 1,
-                    "metadata.last_status_is_active": True,
-                    "active": True,
-                }
-            },
-        )
-
-    def test_deactivate_link(self) -> None:
-        """test deactivate_link."""
-        mock = MagicMock()
-        self.topo._update_link = mock
-        self.topo.deactivate_link(self.link_id, last_status_change=1,
-                                  last_status_is_active=False)
-        self.topo._update_link.assert_called_with(
-            self.link_id,
-            {
-                "$set": {
-                    "metadata.last_status_change": 1,
-                    "metadata.last_status_is_active": False,
-                    "active": False,
-                }
-            },
-        )
 
     def test_add_interface_metadata(self) -> None:
         """test_add_interface_metadata."""


### PR DESCRIPTION
Closes #139 (impacting prod) and #140 (it's explained in the issue the reason why)

### Summary

See updated changelog file

### Local Tests

Trying to simulate and force the race condition with a `time.sleep` doesn't result in the issue anymore:

```
kytos $> 2023-06-19 12:28:57,925 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state 0       
2023-06-19 12:28:57,926 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LINK_DOWN
2023-06-19 12:28:57,927 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state 0
2023-06-19 12:28:57,928 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LINK_DOWN
2023-06-19 12:28:57,930 - INFO [kytos.napps.kytos/topology] [main.py:907:handle_link_down] (thread_pool_sb_8) simulating handle_link_down suspending for 12 secs
2023-06-19 12:29:00,881 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2023-06-19 12:29:00,882 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2023-06-19 12:29:09,948 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_22) Event handle_link_down Link(Interface('s1-eth4', 4, Switch('00:00:00:00
:00:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2023-06-19 12:29:19,979 - INFO [kytos.napps.kytos/mef_eline] [main.py:692:handle_link_up] (thread_pool_app_17) Event handle_link_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:
00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
```

I've also run a script exercising 200 link-flaps over 10 iterations, in all cases the `link_up` event was published afterwards as expected:

```
2023-06-19 12:19:46,099 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LINK_DOWN
2023-06-19 12:19:46,100 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state 0
2023-06-19 12:19:46,101 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LINK_DOWN
2023-06-19 12:19:46,114 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2023-06-19 12:19:46,116 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2023-06-19 12:19:46,128 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state 0
2023-06-19 12:19:46,129 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LINK_DOWN
2023-06-19 12:19:46,130 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state 0
2023-06-19 12:19:46,130 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LINK_DOWN
2023-06-19 12:19:46,142 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2023-06-19 12:19:46,143 - INFO [kytos.napps.kytos/of_core] [main.py:708:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2023-06-19 12:19:52,609 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_8) Event handle_link_down Link(Interface('s1-eth4', 4, Switch('00:00:00:00:
00:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2023-06-19 12:20:02,647 - INFO [kytos.napps.kytos/mef_eline] [main.py:692:handle_link_up] (thread_pool_app_1) Event handle_link_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:0
0:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)


❯ curl -s http://0.0.0.0:8181/api/kytos/topology/v3 | jq | grep UP
            "status": "UP",
            "status": "UP",
            "status": "UP",
            "status": "UP",
            "status": "UP",
        "status": "UP",
            "status": "UP",
            "status": "UP",
            "status": "UP",
            "status": "UP",
        "status": "UP",
            "status": "UP",
            "status": "UP",
            "status": "UP",
            "status": "UP",
        "status": "UP",
          "status": "UP",
          "status": "UP",
        "status": "UP",
          "status": "UP",
          "status": "UP",
        "status": "UP",
          "status": "UP",
          "status": "UP",
        "status": "UP",

❯ curl -s http://0.0.0.0:8181/api/kytos/topology/v3 | jq | grep DOWN
```

```
❯ sudo python flap.py
link_flap test iteration 0
         waiting for 24 secs before next iteration
link_flap test iteration 1
         waiting for 24 secs before next iteration
link_flap test iteration 2
         waiting for 24 secs before next iteration
link_flap test iteration 3
         waiting for 24 secs before next iteration
link_flap test iteration 4
         waiting for 24 secs before next iteration
link_flap test iteration 5
         waiting for 24 secs before next iteration
link_flap test iteration 6
         waiting for 24 secs before next iteration
link_flap test iteration 7
         waiting for 24 secs before next iteration
link_flap test iteration 8
         waiting for 24 secs before next iteration
link_flap test iteration 9
         waiting for 24 secs before next iteration
```

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

import time
import httpx
import subprocess


def do_link_flap(interfaces: list[str]) -> None:
    """perform link flap."""
    for intf in interfaces:
        subprocess.check_output(["sudo", "ip", "link", "set", "dev", intf, "down"])
    for intf in interfaces:
        subprocess.check_output(["sudo", "ip", "link", "set", "dev", intf, "up"])


def assert_topology_link_up(link_id: str) -> None:
    """assert link up."""
    client = httpx.Client(base_url="http://localhost:8181/api/kytos/topology/v3/links")
    resp = client.get("/")
    resp.raise_for_status()
    data = resp.json()
    link = data["links"][link_id]
    assert link["status"] == "UP", link
    assert link["endpoint_a"]["status"] == "UP", link
    assert link["endpoint_b"]["status"] == "UP", data


def main() -> None:
    """Main function."""
    link_flap_iters = 200
    interfaces = ["s1-eth4", "s1-eth4"]
    link_id = "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07"
    wait_for = 24
    test_iters = 10

    for test_iter in range(test_iters):
        print(f"link_flap test iteration {test_iter}")
        assert_topology_link_up(link_id)
        for i in range(link_flap_iters):
            do_link_flap(interfaces)
        print(f"\t waiting for {wait_for} secs before next iteration")
        time.sleep(wait_for)
        assert_topology_link_up(link_id)


if __name__ == "__main__":
    main()
```


### End-to-End Tests

e2e results with this branch, all tests have passed, there was one re-run but completely unrelated to the change:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.1.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 232 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 25%]
tests/test_e2e_11_mef_eline.py ......                                    [ 28%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 31%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 49%]
...                                                                      [ 50%]
tests/test_e2e_14_mef_eline.py x                                         [ 51%]
tests/test_e2e_15_mef_eline.py ..                                        [ 52%]
tests/test_e2e_20_flow_manager.py .....................                  [ 61%]
tests/test_e2e_21_flow_manager.py .R..                                   [ 62%]
tests/test_e2e_22_flow_manager.py ...............                        [ 68%]
tests/test_e2e_23_flow_manager.py ..............                         [ 75%]
tests/test_e2e_30_of_lldp.py ....                                        [ 76%]
tests/test_e2e_31_of_lldp.py ...                                         [ 78%]
tests/test_e2e_32_of_lldp.py ...                                         [ 79%]
tests/test_e2e_40_sdntrace.py ...........                                [ 84%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 87%]
tests/test_e2e_50_maintenance.py ........................                [ 97%]
tests/test_e2e_60_of_multi_table.py .....                                [100%]
=============================== warnings summary ===============================
=========================== rerun test summary info ============================
RERUN tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_031_on_switch_restart_kytos_should_recreate_flows
= 210 passed, 6 skipped, 11 xfailed, 5 xpassed, 833 warnings, 1 rerun in 10798.36s (2:59:58) =
```

I'll submit a PR patching and backporting to `2022.3.2` since it's impacting prod. 


### Extra Notes

@Ktmi we might need to solve potential git conflicts with PR #136, also it's important that you're aware of the changes here. In the future, we'll also handle issue #141, also there's opportunity to unity link notification and metadata (I'll discuss that later with you)