### PR TITLE
Removed old maintenance handlers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ Changed
 - Stopped storing interface and link ``active`` field in the DB
 - Removed ``active`` from the application DB models
 
+Removed
+=======
+- Removed old maintenance listeners ``kytos/maintenance.*``
+
 General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -40,10 +40,6 @@ class TestMain:
         expected_events = [
             'kytos/core.shutdown',
             'kytos/core.shutdown.kytos/topology',
-            'kytos/maintenance.start_link',
-            'kytos/maintenance.end_link',
-            'kytos/maintenance.start_switch',
-            'kytos/maintenance.end_switch',
             'kytos/.*.link_available_tags',
             'kytos/.*.liveness.(up|down)',
             'kytos/.*.liveness.disabled',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -65,10 +65,6 @@ class TestMain:
         expected_events = [
             'kytos/core.shutdown',
             'kytos/core.shutdown.kytos/topology',
-            'kytos/maintenance.start_link',
-            'kytos/maintenance.end_link',
-            'kytos/maintenance.start_switch',
-            'kytos/maintenance.end_switch',
             'kytos/.*.link_available_tags',
             '.*.topo_controller.upsert_switch',
             '.*.of_lldp.network_status.updated',
@@ -1476,90 +1472,6 @@ class TestMain:
         assert bulk_delete.call_count == 1
         assert self.napp.notify_topology_update.call_count == 1
         assert self.napp.notify_link_status_change.call_count == len(links)
-
-    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
-    def test_handle_link_maintenance_start(self, status_change_mock):
-        """Test handle_link_maintenance_start."""
-        link1 = MagicMock()
-        link1.id = 2
-        link2 = MagicMock()
-        link2.id = 3
-        link3 = MagicMock()
-        link3.id = 4
-        content = {'links': [link1.id, link2.id]}
-        event = MagicMock()
-        event.content = content
-        self.napp.links = {2: link1, 4: link3}
-        self.napp.handle_link_maintenance_start(event)
-        status_change_mock.assert_called_once_with(link1, reason='maintenance')
-
-    @patch('napps.kytos.topology.main.Main.notify_link_status_change')
-    def test_handle_link_maintenance_end(self, status_change_mock):
-        """Test handle_link_maintenance_end."""
-        link1 = MagicMock()
-        link1.id = 2
-        link2 = MagicMock()
-        link2.id = 3
-        link3 = MagicMock()
-        link3.id = 4
-        content = {'links': [link1.id, link2.id]}
-        event = MagicMock()
-        event.content = content
-        self.napp.links = {2: link1, 4: link3}
-        self.napp.handle_link_maintenance_end(event)
-        status_change_mock.assert_called_once_with(link1, reason='maintenance')
-
-    @patch('napps.kytos.topology.main.Main.handle_link_down')
-    def test_handle_switch_maintenance_start(self, handle_link_down_mock):
-        """Test handle_switch_maintenance_start."""
-        switch1 = MagicMock()
-        switch1.id = 'a'
-        interface1 = MagicMock()
-        interface1.is_active.return_value = True
-        interface2 = MagicMock()
-        interface2.is_active.return_value = False
-        interface3 = MagicMock()
-        interface3.is_active.return_value = True
-        switch1.interfaces = {1: interface1, 2: interface2, 3: interface3}
-        switch2 = MagicMock()
-        switch2.id = 'b'
-        interface4 = MagicMock()
-        interface4.is_active.return_value = False
-        interface5 = MagicMock()
-        interface5.is_active.return_value = True
-        switch2.interfaces = {1: interface4, 2: interface5}
-        content = {'switches': [switch1.id, switch2.id]}
-        event = MagicMock()
-        event.content = content
-        self.napp.controller.switches = {'a': switch1, 'b': switch2}
-        self.napp.handle_switch_maintenance_start(event)
-        assert handle_link_down_mock.call_count == 3
-
-    @patch('napps.kytos.topology.main.Main.handle_link_up')
-    def test_handle_switch_maintenance_end(self, handle_link_up_mock):
-        """Test handle_switch_maintenance_end."""
-        switch1 = MagicMock()
-        switch1.id = 'a'
-        interface1 = MagicMock()
-        interface1.is_active.return_value = True
-        interface2 = MagicMock()
-        interface2.is_active.return_value = False
-        interface3 = MagicMock()
-        interface3.is_active.return_value = True
-        switch1.interfaces = {1: interface1, 2: interface2, 3: interface3}
-        switch2 = MagicMock()
-        switch2.id = 'b'
-        interface4 = MagicMock()
-        interface4.is_active.return_value = False
-        interface5 = MagicMock()
-        interface5.is_active.return_value = True
-        switch2.interfaces = {1: interface4, 2: interface5}
-        content = {'switches': [switch1.id, switch2.id]}
-        event = MagicMock()
-        event.content = content
-        self.napp.controller.switches = {'a': switch1, 'b': switch2}
-        self.napp.handle_switch_maintenance_end(event)
-        assert handle_link_up_mock.call_count == 5
 
     def test_link_status_hook_link_up_timer(self) -> None:
         """Test status hook link up timer."""


### PR DESCRIPTION
This PR removes the old maintenance handlers, which have been replaced with the interruption handlers. This should resolve the following issues with associated with the old maintenance handlers:

 - kytos-ng/topology#64
 - kytos-ng/topology#62
 - kytos-ng/topology#8
 - kytos-ng/topology#87

### Local Tests

Local tests were performed with kytos-ng/maintenance#78. With this patch, maintenace windows continued to propely dispatch link up and link down events when maintenance windows began and ended.

### End-To-End Test

All maintenance related end to end tests pass. Here are the results:

```
kytos-end-to-end-tests-kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-end-to-end-tests-kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-end-to-end-tests-kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-end-to-end-tests-kytos-1  | Starting ovsdb-server.
kytos-end-to-end-tests-kytos-1  | Configuring Open vSwitch system IDs.
kytos-end-to-end-tests-kytos-1  | Starting ovs-vswitchd.
kytos-end-to-end-tests-kytos-1  | Enabling remote OVSDB managers.
kytos-end-to-end-tests-kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + kytosd --help
kytos-end-to-end-tests-kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + TESTS=tests/
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + RERUNS=2
kytos-end-to-end-tests-kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-end-to-end-tests-kytos-1  | Trying to run hello command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-end-to-end-tests-kytos-1  | + python3 -m pytest tests/test_e2e_50_maintenance.py
kytos-end-to-end-tests-kytos-1  | ============================= test session starts ==============================
kytos-end-to-end-tests-kytos-1  | platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.2.0
kytos-end-to-end-tests-kytos-1  | rootdir: /tests
kytos-end-to-end-tests-kytos-1  | plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
kytos-end-to-end-tests-kytos-1  | collected 24 items
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_50_maintenance.py ........................                [100%]
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | =============================== warnings summary ===============================
kytos-end-to-end-tests-kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-end-to-end-tests-kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-end-to-end-tests-kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-end-to-end-tests-kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-end-to-end-tests-kytos-1  |     StrictVersion( '1.10' ) )
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-end-to-end-tests-kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-end-to-end-tests-kytos-1  | ================= 24 passed, 34 warnings in 1574.08s (0:26:14) =================
```
