### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,27 @@ All notable changes to the ``topology`` project will be documented in this file.
 
 Added
 =====
+
+Deprecated
+==========
+
+Removed
+=======
+
+Fixed
+=====
+
+Security
+========
+
+Changed
+=======
+
+[2023.1.0] - 2023-06-26
+***********************
+
+Added
+=====
  - Info on status and status_reason to UI for Switches and Interfaces
  - Listener for service interruptions through ``topology.interruption.(start|end)``
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2022.3.0",
+  "version": "2023.1.0",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],


### PR DESCRIPTION
Closes #135

### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Results are pending