### PR TITLE
feat: publish `kytos/topology.update` when changing link metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 Removed
 =======
 - Removed old maintenance listeners ``kytos/maintenance.*``
+- Removed ``kytos/topology.get``
 
 General Information
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Added
 =====
  - Info on status and status_reason to UI for Switches and Interfaces
  - Listener for service interruptions through ``topology.interruption.(start|end)``
+ - Publishes ``kytos/topology.update`` when changing link metadata
 
 Fixed
 =====

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,6 @@ Subscribed
 - ``kytos/maintenance.end_switch``
 - ``kytos/.*.liveness.(up|down)``
 - ``kytos/.*.liveness.disabled``
-- ``kytos/topology.get``
 - ``kytos/topology.notify_link_up_if_status``
 
 
@@ -90,20 +89,6 @@ kytos/topology.updated
 
 Event reporting that the topology was updated. It contains the most updated
 topology.
-
-Content:
-
-.. code-block:: python3
-
-   {
-     'topology': <Topology object>
-   }
-
-kytos/topology.current
-~~~~~~~~~~~~~~~~~~~~~~
-
-Event reporting the current topology, this is meant as a broadcast response when
-a subscriber needs it for reconciliation.
 
 Content:
 

--- a/main.py
+++ b/main.py
@@ -548,6 +548,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller.add_link_metadata(link_id, metadata)
         link.extend_metadata(metadata)
         self.notify_metadata_changes(link, 'added')
+        self.notify_topology_update()
         return JSONResponse("Operation successful", status_code=201)
 
     @rest('v3/links/{link_id}/metadata/{key}', methods=['DELETE'])
@@ -568,6 +569,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller.delete_link_metadata_key(link.id, key)
         link.remove_metadata(key)
         self.notify_metadata_changes(link, 'removed')
+        self.notify_topology_update()
         return JSONResponse("Operation successful")
 
     def notify_current_topology(self) -> None:

--- a/main.py
+++ b/main.py
@@ -572,18 +572,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_topology_update()
         return JSONResponse("Operation successful")
 
-    def notify_current_topology(self) -> None:
-        """Notify current topology."""
-        name = "kytos/topology.current"
-        event = KytosEvent(name=name, content={"topology":
-                                               self._get_topology()})
-        self.controller.buffers.app.put(event)
-
-    @listen_to("kytos/topology.get")
-    def on_get_topology(self, _event) -> None:
-        """Handle kytos/topology.get."""
-        self.notify_current_topology()
-
     @listen_to("kytos/.*.liveness.(up|down)")
     def on_link_liveness_status(self, event) -> None:
         """Handle link liveness up|down status event."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -43,7 +43,6 @@ class TestMain:
             'kytos/.*.link_available_tags',
             'kytos/.*.liveness.(up|down)',
             'kytos/.*.liveness.disabled',
-            'kytos/topology.get',
             '.*.topo_controller.upsert_switch',
             '.*.of_lldp.network_status.updated',
             '.*.interface.is.nni',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -78,7 +78,6 @@ class TestMain:
             '.*.switch.(new|reconnected)',
             'kytos/.*.liveness.(up|down)',
             'kytos/.*.liveness.disabled',
-            'kytos/topology.get',
             '.*.switch.port.created',
             'kytos/topology.notify_link_up_if_status',
             'topology.interruption.start',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1379,17 +1379,6 @@ class TestMain:
         self.napp.notify_topology_update()
         mock_buffers_put.assert_called()
 
-    def test_notify_current_topology(self):
-        """Test notify_current_topology."""
-        mock_buffers_put = MagicMock()
-        self.napp.controller.buffers.app.put = mock_buffers_put
-        self.napp.notify_current_topology()
-        mock_buffers_put.assert_called()
-        args = mock_buffers_put.call_args
-        expected_event = args[0][0]
-        assert expected_event.name == "kytos/topology.current"
-        assert "topology" in expected_event.content
-
     def test_notify_link_status_change(self):
         """Test notify link status change."""
         mock_buffers_put = MagicMock()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1009,8 +1009,14 @@ class TestMain:
         response = await self.api_client.get(endpoint)
         assert response.status_code == 404
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
-    async def test_add_link_metadata(self, mock_metadata_changes, event_loop):
+    async def test_add_link_metadata(
+        self,
+        mock_metadata_changes,
+        mock_topology_update,
+        event_loop
+    ):
         """Test add_link_metadata."""
         self.napp.controller.loop = event_loop
         mock_link = MagicMock(Link)
@@ -1023,6 +1029,7 @@ class TestMain:
         response = await self.api_client.post(endpoint, json=payload)
         assert response.status_code == 201
         mock_metadata_changes.assert_called()
+        mock_topology_update.assert_called()
 
         # fail case
         link_id = 2
@@ -1043,8 +1050,13 @@ class TestMain:
         response = await self.api_client.post(endpoint, json=payload)
         assert response.status_code == 415
 
+    @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_metadata_changes')
-    async def test_delete_link_metadata(self, mock_metadata_changes):
+    async def test_delete_link_metadata(
+        self,
+        mock_metadata_changes,
+        mock_topology_update
+    ):
         """Test delete_link_metadata."""
         mock_link = MagicMock(Link)
         mock_link.metadata = {"A": "A"}
@@ -1059,6 +1071,7 @@ class TestMain:
         del_mock = self.napp.topo_controller.delete_link_metadata_key
         del_mock.assert_called_once_with(mock_link.id, key)
         mock_metadata_changes.assert_called()
+        mock_topology_update.assert_called()
 
         # fail case link not found
         link_id = 2


### PR DESCRIPTION
This is needed for https://github.com/kytos-ng/pathfinder/pull/55

I'll send a PR backporting soon

### Summary

See updated changelog file 

### Local Tests

Executed on https://github.com/kytos-ng/pathfinder/pull/55

### End-to-End Tests

Executed on https://github.com/kytos-ng/pathfinder/pull/55
