### PR TITLE
[release 2022.3.3] feat: publish `kytos/topology.update` when changing link metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.3] - 2022-07-06
+***********************
+
+Added
+=====
+- Publishes ``kytos/topology.update`` when changing link metadata
+
+Removed
+=======
+- Removed ``kytos/topology.get``
+
 [2022.3.2] - 2023-06-19
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,6 @@ Subscribed
 - ``kytos/maintenance.end_switch``
 - ``kytos/.*.liveness.(up|down)``
 - ``kytos/.*.liveness.disabled``
-- ``kytos/topology.get``
 - ``kytos/topology.notify_link_up_if_status``
 
 
@@ -99,19 +98,6 @@ Content:
      'topology': <Topology object>
    }
 
-kytos/topology.current
-~~~~~~~~~~~~~~~~~~~~~~
-
-Event reporting the current topology, this is meant as a broadcast response when
-a subscriber needs it for reconciliation.
-
-Content:
-
-.. code-block:: python3
-
-   {
-     'topology': <Topology object>
-   }
 
 kytos/topology.switch.enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2022.3.2",
+  "version": "2022.3.3",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -539,6 +539,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller.add_link_metadata(link_id, metadata)
         link.extend_metadata(metadata)
         self.notify_metadata_changes(link, 'added')
+        self.notify_topology_update()
         return jsonify("Operation successful"), 201
 
     @rest('v3/links/<link_id>/metadata/<key>', methods=['DELETE'])
@@ -557,6 +558,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller.delete_link_metadata_key(link.id, key)
         link.remove_metadata(key)
         self.notify_metadata_changes(link, 'removed')
+        self.notify_topology_update()
         return jsonify("Operation successful"), 200
 
     def notify_current_topology(self) -> None:

--- a/main.py
+++ b/main.py
@@ -561,18 +561,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_topology_update()
         return jsonify("Operation successful"), 200
 
-    def notify_current_topology(self) -> None:
-        """Notify current topology."""
-        name = "kytos/topology.current"
-        event = KytosEvent(name=name, content={"topology":
-                                               self._get_topology()})
-        self.controller.buffers.app.put(event)
-
-    @listen_to("kytos/topology.get")
-    def on_get_topology(self, _event) -> None:
-        """Handle kytos/topology.get."""
-        self.notify_current_topology()
-
     @listen_to("kytos/.*.liveness.(up|down)")
     def on_link_liveness_status(self, event) -> None:
         """Handle link liveness up|down status event."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -143,7 +143,6 @@ class TestMain(TestCase):
                            'kytos/.*.link_available_tags',
                            'kytos/.*.liveness.(up|down)',
                            'kytos/.*.liveness.disabled',
-                           'kytos/topology.get',
                            '.*.topo_controller.upsert_switch',
                            '.*.of_lldp.network_status.updated',
                            '.*.interface.is.nni',


### PR DESCRIPTION
### Summary

This is backport from https://github.com/kytos-ng/topology/pull/150, check [PR 150](https://github.com/kytos-ng/topology/pull/150) out for more information.