### PR TITLE
feature: Added endpoints to set and delete `tag_range`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,9 +11,13 @@ Added
 =====
 - Added endpoint ``POST v3/interfaces/{interface_id}/tag_ranges`` to set ``tag_ranges`` to interfaces.
 - Added endpoint ``DELETE v3/interfaces/{interface_id}/tag_ranges`` to delete ``tag_ranges`` from interfaces.
+- Added ``Tag_ranges`` documentation to openapi.yml
+- Added API request POST and DELETE to modify ``Interface.tag_ranges``
+- Added listener for ``kytos/core.interface_tags`` event to save any changes made to ``Interface`` attributes ``tag_ranges`` and ``available_tags``
 
 Deprecated
 ==========
+- Deleted event listener for ``kytos/.*.link_available_tags`` event
 
 Removed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ All notable changes to the ``topology`` project will be documented in this file.
 
 Added
 =====
+- Added endpoint ``POST v3/interfaces/{interface_id}/tag_ranges`` to set ``tag_ranges`` to interfaces.
+- Added endpoint ``DELETE v3/interfaces/{interface_id}/tag_ranges`` to delete ``tag_ranges`` from interfaces.
 
 Deprecated
 ==========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,10 @@ Security
 Changed
 =======
 
+General Information
+===================
+- ``scripts/vlan_pool.py`` can be used to change the collection ``interface_details`` to have ``available_tags`` and ``tag_ranges``
+
 [2023.1.0] - 2023-06-26
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Subscribed
 - ``.*.switch.port.deleted``
 - ``.*.interface.is.nni``
 - ``.*.network_status.updated``
-- ``kytos/.*.link_available_tags``
+- ``kytos/core.interface_tags``
 - ``kytos/maintenance.start_link``
 - ``kytos/maintenance.end_link``
 - ``kytos/maintenance.start_switch``

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-name-in-module
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field, conlist, validator
 
@@ -124,4 +124,5 @@ class LinkDoc(DocumentBaseModel):
 class InterfaceDetailDoc(DocumentBaseModel):
     """InterfaceDetail DB Document Model."""
 
-    available_vlans: List[int]
+    available_tags: Dict[str, List[List[int]]]
+    tag_ranges: Dict[str, List[List[int]]]

--- a/main.py
+++ b/main.py
@@ -46,7 +46,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                                      DEFAULT_LINK_UP_TIMER)
 
         self._links_lock = Lock()
-        self._interface_lock = Lock()
         self._links_notify_lock = defaultdict(Lock)
         # to keep track of potential unorded scheduled interface events
         self._intfs_lock = defaultdict(Lock)
@@ -208,7 +207,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
         intf_ids = [v["id"] for v in switch_att.get("interfaces", {}).values()]
         intf_details = self.topo_controller.get_interfaces_details(intf_ids)
-        with self._interface_lock:
+        with self._links_lock:
             self.load_interfaces_tags_values(switch, intf_details)
 
     # pylint: disable=attribute-defined-outside-init

--- a/main.py
+++ b/main.py
@@ -555,7 +555,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         except KytosTagtypeNotSupported as err:
             detail = f"Error with tag_type. {err}"
             raise HTTPException(400, detail=detail)
-        raise HTTPException(200, detail="Operation Successful")
+        return JSONResponse("Operation Successful", status_code=200)
 
     @rest('v3/interfaces/{interface_id}/tag_ranges', methods=['DELETE'])
     @validate_openapi(spec)
@@ -573,7 +573,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         except KytosTagtypeNotSupported as err:
             detail = f"Error with tag_type. {err}"
             raise HTTPException(400, detail=detail)
-        raise HTTPException(200, detail="Operation Successful")
+        return JSONResponse("Operation Successful", status_code=200)
 
     # Link related methods
     @rest('v3/links')

--- a/main.py
+++ b/main.py
@@ -548,7 +548,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(404, detail="Interface not found")
         try:
             interface.set_tag_ranges(ranges, tag_type)
-            interface.notify_interface_tags(self.controller)
+            self.handle_on_interface_tags(interface)
         except KytosSetTagRangeError as err:
             detail = f"The new tag_ranges cannot be applied {err}"
             raise HTTPException(400, detail=detail)
@@ -569,10 +569,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(404, detail="Interface not found")
         try:
             interface.remove_tag_ranges(tag_type)
+            self.handle_on_interface_tags(interface)
         except KytosTagtypeNotSupported as err:
             detail = f"Error with tag_type. {err}"
             raise HTTPException(400, detail=detail)
-        interface.notify_interface_tags(self.controller)
         raise HTTPException(200, detail="Operation Successful")
 
     # Link related methods

--- a/main.py
+++ b/main.py
@@ -487,7 +487,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         return JSONResponse("Operation successful")
 
     @staticmethod
-    def mapp_singular_values(tag_range):
+    def map_singular_values(tag_range):
         """Change integer or singular interger list to
         list[int, int] when necessary"""
         if isinstance(tag_range, int):
@@ -508,7 +508,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(400, detail=detail)
         last_tag = 0
         for i, _ in enumerate(ranges):
-            ranges[i] = self.mapp_singular_values(ranges[i])
+            ranges[i] = self.map_singular_values(ranges[i])
             if ranges[i][0] > ranges[i][1]:
                 detail = f"The range {ranges[i]} is not ordered"
                 raise HTTPException(400, detail=detail)

--- a/main.py
+++ b/main.py
@@ -1153,9 +1153,15 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                       "available tags")
             port_number = int(interface_details["id"].split(":")[-1])
             interface = switch.interfaces[port_number]
+            available_tags = {}
+            for key, value in interface_details['available_tags'].items():
+                available_tags[int(key)] = value
+            tag_ranges = {}
+            for key, value in interface_details['tag_ranges'].items():
+                tag_ranges[int(key)] = value
             interface.set_available_tags_tag_ranges(
-                interface_details['available_tags'],
-                interface_details['tag_ranges']
+                available_tags,
+                tag_ranges
             )
 
     @listen_to('topology.interruption.start')

--- a/openapi.yml
+++ b/openapi.yml
@@ -411,7 +411,7 @@ paths:
                 example: Switch not found
   /api/kytos/topology/v3/interfaces/{interface_id}/tag_ranges:
     post:
-      summary: Add/modify tag_range from an interface
+      summary: Set tag_range from an interface
       parameters:
         - name: interface_id
           schema:
@@ -420,10 +420,18 @@ paths:
           description: The interface ID
           in: path
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/Tag_ranges'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request.
+        '404':
+          description: Switch or Interface not found.
     delete:
       summary: Delete tag_range from an interface
       parameters:
@@ -440,7 +448,13 @@ paths:
           description: Type of the tag to be modified
           required: false
           example: 1
-
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request.
+        '404':
+          description: Switch or Interface not found.
   /api/kytos/topology/v3/links:
     get:
       summary: Return a json with all the links in the topology.
@@ -722,3 +736,19 @@ components:
           $ref: '#/components/schemas/Interface'
         endpoint_b:
           $ref: '#/components/schemas/Interface'
+    Tag_ranges: # Can be referenced via '#/components/schemas/Tag_ranges'
+      type: object
+      required:
+        - tag_type
+        - tag_ranges
+      properties:
+        tag_type:
+          type: string
+        tag_ranges:
+          type: array
+          items:
+            anyOf:
+              - type: array
+              - type: integer
+          example: [[1, 500], 2096, [3001]]
+

--- a/openapi.yml
+++ b/openapi.yml
@@ -433,7 +433,7 @@ paths:
         '404':
           description: Switch or Interface not found.
     delete:
-      summary: Delete tag_range from an interface
+      summary: Set tag ranges from an Interface for a given tag_type to default value [1, 4095]
       parameters:
         - name: interface_id
           schema:
@@ -743,12 +743,13 @@ components:
         - tag_ranges
       properties:
         tag_type:
-          type: string
+          type: integer
+          enum: [1]
         tag_ranges:
           type: array
+          minItems: 1
           items:
             anyOf:
               - type: array
               - type: integer
           example: [[1, 500], 2096, [3001]]
-

--- a/openapi.yml
+++ b/openapi.yml
@@ -4,7 +4,7 @@ info:
   version: v3
   description: Manage the network topology.
 servers:
-  - url: http://localhost:8181/
+  - url: /api/kytos/topology
     description: Local server (uses test data)
 paths:
   /api/kytos/topology/v3/:
@@ -409,7 +409,7 @@ paths:
               schema:
                 type: string
                 example: Switch not found
-  /api/kytos/topology/v3/interfaces/{interface_id}/tag_ranges:
+  /v3/interfaces/{interface_id}/tag_ranges:
     post:
       summary: Set tag_range from an interface
       parameters:
@@ -447,7 +447,7 @@ paths:
             type: string
           description: Type of the tag to be modified
           required: false
-          example: 1
+          example: vlan
       responses:
         '200':
           description: Ok
@@ -743,8 +743,8 @@ components:
         - tag_ranges
       properties:
         tag_type:
-          type: integer
-          enum: [1]
+          type: string
+          enum: ['vlan']
         tag_ranges:
           type: array
           minItems: 1

--- a/openapi.yml
+++ b/openapi.yml
@@ -409,6 +409,38 @@ paths:
               schema:
                 type: string
                 example: Switch not found
+  /api/kytos/topology/v3/interfaces/{interface_id}/tag_ranges:
+    post:
+      summary: Add/modify tag_range from an interface
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: The interface ID
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+    delete:
+      summary: Delete tag_range from an interface
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: The interface ID
+          in: path
+        - name: tag_type
+          in: query
+          schema:
+            type: string
+          description: Type of the tag to be modified
+          required: false
+          example: 1
+
   /api/kytos/topology/v3/links:
     get:
       summary: Return a json with all the links in the topology.

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@epic/vlan_pool#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
 -e .

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_pool#egg=kytos[dev]
 -e .

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -181,10 +181,53 @@ export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
 
 #### How to use
 
-Run the script to change every ``tag_type`` to string
+- The following `CMD` commands are available:
 
 ```
-python3 vlan_pool.py
+aggregate_outdated_interfaces
+update_database
+```
+
+`aggregate_outdated_interfaces` option is to see how many documents are going to be modified and how many are going to be added.
+
+```
+CMD=aggregate_outdated_interfaces python3 scripts/storehouse_to_mongo.py
+```
+
+For the documents that are going to be modified, only the maximum and minimum value are going to be shown:
+
+```
+{'id': '00:00:00:00:00:00:00:01:3', 'max_number': 4095, 'min_number': 2}
+```
+
+For soon to be added documents, `avoid_tags` set is going to be shown representing the tags that are used and will need to be avoided in `available_tags`:
+
+```
+{'id': '00:00:00:00:00:00:00:01:1', 'avoid_tags': {200}}
+```
+
+A `WARNING` is going to be shown if a duplicated `TAG` is detected in different `EVC`s:
+
+```
+WARNING: Detected duplicated 200 TAG in EVCs 861a11d8fce148 and d74e18464d524b in interface 00:00:00:00:00:00:00:01:1
+```
+
+`update_database` updates and adds the required documents for compatability
+
+```
+CMD=aggregate_outdated_interfaces python3 scripts/storehouse_to_mongo.py
+```
+
+The final messages will show how many documents have been modified and added
+
+```
+6 documents modified. 3 documents inserted
+```
+
+An `ERROR` can be shown if a duplicated `TAG` is detected in different `EVC`s. After this the pocess will exit without making any modification or adittion.
+
+```
+Error: Detected duplicated 200 TAG in EVCs 861a11d8fce148 and d74e18464d524b in interface 00:00:00:00:00:00:00:01:1
 ```
 
 </details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -153,3 +153,38 @@ Modified 0 switches objects
 ```
 
 </details>
+
+<details><summary><h3>Change <code>tag_type</code> from integer to string type</h3></summary>
+
+[`vlan_pool.py`](./vlan_pool.py) is a script to change ``available_vlans`` to ``available_tags``. Also adding new field ``tag_ranges``. These new fields have the type ``dict[str, list[list[int]]]``. Example
+
+```
+    available_tags = {"vlan": [[1, 299], [301, 4095]]}
+    tag_ranges = {"vlan": [[1, 4095]]}
+```
+
+This scripts takes into account UNIs TAG values as well.
+
+#### Pre-requisites
+
+- There's no additional Python libraries dependencies required, other than installing the existing `topology`'s, or if you're running in development locally then installing `requirements/dev.in`
+- Make sure you don't have `kytosd` running with otherwise topology will start writing to MongoDB, and the application could overwrite the data you're trying to insert with this script.
+- Make sure MongoDB replica set is up and running.
+- Export the following MongnoDB variables accordingly in case your running outside of a container
+
+```
+export MONGO_USERNAME=
+export MONGO_PASSWORD=
+export MONGO_DBNAME=napps
+export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
+```
+
+#### How to use
+
+Run the script to change every ``tag_type`` to string
+
+```
+python3 vlan_pool.py
+```
+
+</details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -191,7 +191,7 @@ update_database
 `aggregate_outdated_interfaces` option is to see how many documents are going to be modified and how many are going to be added.
 
 ```
-CMD=aggregate_outdated_interfaces python3 scripts/storehouse_to_mongo.py
+CMD=aggregate_outdated_interfaces python3 scripts/vlan_pool.py
 ```
 
 For the documents that are going to be modified, only the maximum and minimum value are going to be shown:
@@ -215,7 +215,7 @@ WARNING: Detected duplicated 200 TAG in EVCs 861a11d8fce148 and d74e18464d524b i
 `update_database` updates and adds the required documents for compatability
 
 ```
-CMD=aggregate_outdated_interfaces python3 scripts/storehouse_to_mongo.py
+CMD=update_database python3 scripts/vlan_pool.py
 ```
 
 The final messages will show how many documents have been modified and added

--- a/scripts/vlan_pool.py
+++ b/scripts/vlan_pool.py
@@ -1,6 +1,8 @@
 import datetime
+import sys
+import os
 from collections import defaultdict
-from kytos.core.db import mongo_client
+from kytos.core.db import Mongo
 
 DEFAULT_TAG_RANGES = [[1, 4095]]
 
@@ -32,7 +34,8 @@ def get_range(vlans, avoid) -> list[list[int]]:
     result.append([start, end])
     return result
 
-def generate_ranges(avoid):
+def generate_ranges(avoid) -> [list[list[int]]]:
+    """Generate available_tags only from avoid"""
     if not avoid:
         return DEFAULT_TAG_RANGES
 
@@ -49,52 +52,146 @@ def generate_ranges(avoid):
         ranges.append([start, 4095])
     return ranges
 
-client = mongo_client()
-intf_collection = client["napps"]["interface_details"]
-evc_collection = client["napps"]["evcs"]
-intf_documents = intf_collection.find()
-evc_documents = evc_collection.find()
+def update_database(mongo: Mongo):
+    """Update database"""
+    db = mongo.client[mongo.db_name]
+    intf_documents = db.interface_details.find()
+    evc_documents = db.evcs.find()
 
-evc_intf_dict = defaultdict(set)
+    evc_intf = defaultdict(set)
+    evc_tags = defaultdict(set)
 
-for evc in evc_documents:
-    tag_a = evc["uni_a"].get("tag")
-    if tag_a:
-        intf_id = evc["uni_a"]["interface_id"]
-        evc_intf_dict[intf_id].add(tag_a["value"])
+    for evc in evc_documents:
+        tag_a = evc["uni_a"].get("tag")
+        if tag_a:
+            intf_id = evc["uni_a"]["interface_id"]
+            if tag_a["value"] in evc_tags[intf_id]:
+                print(f"Error: Detected duplicated {tag_a['value']} TAG"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in interface {intf_id}")
+                sys.exit(1)
+            evc_tags[intf_id].add(tag_a["value"])
+            evc_intf[intf_id].add(evc["id"])
 
-    tag_z = evc["uni_z"].get("tag")
-    if tag_z:
-        intf_id = evc["uni_z"]["interface_id"]
-        evc_intf_dict[intf_id].add(tag_z["value"])
+        tag_z = evc["uni_z"].get("tag")
+        if tag_z:
+            intf_id = evc["uni_z"]["interface_id"]
+            if tag_z["value"] in evc_tags[intf_id]:
+                print(f"Error: Detected duplicated {tag_z['value']} TAG"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in interface {intf_id}")
+                sys.exit(1)
+            evc_tags[intf_id].add(tag_z["value"])
+            evc_intf[intf_id].add(evc["id"])
 
-for document in intf_documents:
-    if document.get("available_vlans") is None:
-        continue
-    avoid_tags = evc_intf_dict.pop(document["id"], set())
-    ranges = get_range(document["available_vlans"], avoid_tags)
-    intf_collection.update_one(
-        {"id": document["id"]},
-        {
-            "$set": 
+    intf_count = 0
+    for document in intf_documents:
+        avoid_tags = evc_tags.pop(document["id"], set())
+        ranges = get_range(document["available_vlans"], avoid_tags)
+        result = db.interface_details.update_one(
+            {"id": document["id"]},
             {
-                "available_tags": {"vlan": ranges},
-                "tag_ranges": {"vlan": DEFAULT_TAG_RANGES}
-            },
-            "$unset": {"available_vlans": ""}
-        }
+                "$set": 
+                {
+                    "available_tags": {"vlan": ranges},
+                    "tag_ranges": {"vlan": DEFAULT_TAG_RANGES}
+                },
+                "$unset": {"available_vlans": ""}
+            }
+        )
+        intf_count += result.modified_count
+
+    evc_intf_count = 0
+    for intf_id, avoid_tags in evc_tags.items():
+        available_tags = generate_ranges(list(avoid_tags))
+        utc_now = datetime.datetime.utcnow()
+        result = db.interface_details.insert_one({
+            "_id": intf_id,
+            "id": intf_id,
+            "inserted_at": utc_now,
+            "updated_at": utc_now,
+            "available_tags": {"vlan": available_tags},
+            "tag_ranges": {"vlan": DEFAULT_TAG_RANGES},
+        })
+        if result:
+            evc_intf_count += 1
+
+    print(f"{intf_count} documents modified. {evc_intf_count} documents inserted")
+
+def aggregate_outdated_interfaces(mongo: Mongo):
+    """Aggregate outdated inteface details"""
+    db = mongo.client[mongo.db_name]
+    document_ids = set()
+    result = db.interface_details.aggregate(
+        [
+            {"$sort": {"_id": 1}},
+            {"$project": {
+                "_id": 0,
+                "id": 1,
+                "max_number": {"$max": "$available_vlans"},
+                "min_number": {"$min": "$available_vlans"},
+            }}
+        ]
     )
+    print("Here are the outdated interfaces. 'available_vlans' have a massive"
+          " amount of items, minimum and maximum items will be shown only")
+    for document in result:
+        print(document)
+        document_ids.add(document["id"])
+    print()
+    
+    evc_documents = db.evcs.find()
+    evc_intf = defaultdict(set)
+    evc_tags = defaultdict(set)
 
-for intf_id, avoid_tags in evc_intf_dict.items():
-    available_tags = generate_ranges(list(avoid_tags))
-    utc_now = datetime.datetime.utcnow()
-    intf_collection.insert_one({
-        "_id": intf_id,
-        "id": intf_id,
-        "inserted_at": utc_now,
-        "updated_at": utc_now,
-        "available_tags": {"vlan": available_tags},
-        "tag_ranges": {"vlan": DEFAULT_TAG_RANGES},
-    })
+    for evc in evc_documents:
+        tag_a = evc["uni_a"].get("tag")
+        if tag_a:
+            intf_id = evc["uni_a"]["interface_id"]
+            if tag_a["value"] in evc_tags[intf_id]:
+                print(f"WARNING: Detected duplicated {tag_a['value']} TAG"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in interface {intf_id}")
+                print()
+            evc_tags[intf_id].add(tag_a["value"])
+            evc_intf[intf_id].add(evc["id"])
 
-print("Finnished adding available_tags and tag_ranges")
+        tag_z = evc["uni_z"].get("tag")
+        if tag_z:
+            intf_id = evc["uni_z"]["interface_id"]
+            if tag_z["value"] in evc_tags[intf_id]:
+                print(f"WARNING: Detected duplicated {tag_z['value']} TAG"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in interface {intf_id}")
+                print()
+            evc_tags[intf_id].add(tag_z["value"])
+            evc_intf[intf_id].add(evc["id"])
+
+    for id_ in document_ids:
+        evc_tags.pop(id_, None)
+
+    if evc_tags:
+        print("New documents are going to be created. From the next interfaces,"
+              " these tags should be avoided")
+
+    for intf, avoid_tags in evc_tags.items():
+        if intf in document_ids:
+            continue
+        aux = {"id": intf, "avoid_tags": avoid_tags}
+        print(aux)
+
+
+if __name__ == "__main__":
+    mongo = Mongo()
+    cmds = {
+        "aggregate_outdated_interfaces": aggregate_outdated_interfaces,
+        "update_database": update_database,
+    }
+    try:
+        cmd = os.environ["CMD"]
+        cmds[cmd](mongo)
+    except KeyError:
+        print(
+            f"Please set the 'CMD' env var. \nIt has to be one of these: {list(cmds.keys())}"
+        )
+        sys.exit(1)

--- a/scripts/vlan_pool.py
+++ b/scripts/vlan_pool.py
@@ -10,7 +10,7 @@ def get_range(vlans, avoid) -> list[list[int]]:
     result = []
     if not vlans:
         return result
-
+    vlans.sort()
     i = 0
     while i < len(vlans):
         if vlans[i] in avoid:

--- a/scripts/vlan_pool.py
+++ b/scripts/vlan_pool.py
@@ -1,0 +1,100 @@
+import datetime
+from collections import defaultdict
+from kytos.core.db import mongo_client
+
+DEFAULT_TAG_RANGES = [[1, 4095]]
+
+def get_range(vlans, avoid) -> list[list[int]]:
+    """Convert available_vlans to available_tags.
+    From list[int] to list[list[int]]"""
+    result = []
+    if not vlans:
+        return result
+
+    i = 0
+    while i < len(vlans):
+        if vlans[i] in avoid:
+            i += 1
+        else:
+            break
+    if not vlans[i:]:
+        return result
+
+    start = end = vlans[i]
+    for tag in vlans[i+1:]:
+        if tag in avoid:
+            continue
+        if tag == end + 1:
+            end = tag
+        else:
+            result.append([start, end])
+            start = end = tag
+    result.append([start, end])
+    return result
+
+def generate_ranges(avoid):
+    if not avoid:
+        return DEFAULT_TAG_RANGES
+
+    avoid.sort()
+    ranges = []
+    start = 1
+
+    for num in avoid:
+        if num > start:
+            ranges.append([start, num - 1])
+        start = num + 1
+
+    if start <= 4095:
+        ranges.append([start, 4095])
+    return ranges
+
+client = mongo_client()
+intf_collection = client["napps"]["interface_details"]
+evc_collection = client["napps"]["evcs"]
+intf_documents = intf_collection.find()
+evc_documents = evc_collection.find()
+
+evc_intf_dict = defaultdict(set)
+
+for evc in evc_documents:
+    tag_a = evc["uni_a"].get("tag")
+    if tag_a:
+        intf_id = evc["uni_a"]["interface_id"]
+        evc_intf_dict[intf_id].add(tag_a["value"])
+
+    tag_z = evc["uni_z"].get("tag")
+    if tag_z:
+        intf_id = evc["uni_z"]["interface_id"]
+        evc_intf_dict[intf_id].add(tag_z["value"])
+
+for document in intf_documents:
+    if document.get("available_vlans") is None:
+        continue
+    avoid_tags = evc_intf_dict.pop(document["id"], set())
+    ranges = get_range(document["available_vlans"], avoid_tags)
+    intf_collection.update_one(
+        {"id": document["id"]},
+        {
+            "$set": 
+            {
+                "available_tags": {"vlan": ranges},
+                "tag_ranges": {"vlan": DEFAULT_TAG_RANGES}
+            },
+            "$unset": {"available_vlans": ""}
+        }
+    )
+
+for intf_id, avoid_tags in evc_intf_dict.items():
+    available_tags = generate_ranges(list(avoid_tags))
+    utc_now = datetime.datetime.utcnow()
+    intf_collection.insert_one({
+        "_id": intf_id,
+        "id": intf_id,
+        "inserted_at": utc_now,
+        "updated_at": utc_now,
+        "available_tags": {"vlan": available_tags},
+        "tag_ranges": {"vlan": DEFAULT_TAG_RANGES},
+    })
+
+print("Finnished adding available_tags and tag_ranges")

--- a/scripts/vlan_pool.py
+++ b/scripts/vlan_pool.py
@@ -132,6 +132,7 @@ def aggregate_outdated_interfaces(mongo: Mongo):
                 "id": 1,
                 "max_number": {"$max": "$available_vlans"},
                 "min_number": {"$min": "$available_vlans"},
+                "available_vlans": 1,
             }}
         ]
     )
@@ -141,13 +142,13 @@ def aggregate_outdated_interfaces(mongo: Mongo):
         document_ids.add(document["id"])
         if document.get("available_vlans") is None:
             continue
+        document.pop("available_vlans")
         messages += str(document) + "\n"
 
     if messages != "":
         print("Here are the outdated interfaces. 'available_vlans' have a massive"
           " amount of items, minimum and maximum items will be shown only")
         print(messages)
-        print()
     
     evc_documents = db.evcs.find()
     evc_intf = defaultdict(set)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -40,7 +40,6 @@ class TestMain:
         expected_events = [
             'kytos/core.shutdown',
             'kytos/core.shutdown.kytos/topology',
-            'kytos/.*.link_available_tags',
             'kytos/.*.liveness.(up|down)',
             'kytos/.*.liveness.disabled',
             '.*.topo_controller.upsert_switch',
@@ -57,6 +56,7 @@ class TestMain:
             'kytos/topology.notify_link_up_if_status',
             'topology.interruption.start',
             'topology.interruption.end',
+            'kytos/core.interface_tags',
         ]
         assert sorted(expected_events) == sorted(actual_events)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1689,7 +1689,7 @@ class TestMain:
         mock_switch = get_switch_mock(dpid)
         mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
         mock_interface.set_tag_ranges = MagicMock()
-        mock_interface.notify_interface_tags = MagicMock()
+        self.napp.handle_on_interface_tags = MagicMock()
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = mock_interface
         payload = {
@@ -1703,7 +1703,7 @@ class TestMain:
         args = mock_interface.set_tag_ranges.call_args[0]
         assert args[0] == payload['tag_ranges']
         assert args[1] == payload['tag_type']
-        assert mock_interface.notify_interface_tags.call_count == 1
+        assert self.napp.handle_on_interface_tags.call_count == 1
 
     async def test_set_tag_range_not_found(self, event_loop):
         """Test set_tag_range. Not found"""
@@ -1749,7 +1749,7 @@ class TestMain:
         mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
         mock_interface.set_tag_ranges = MagicMock()
         mock_interface.set_tag_ranges.side_effect = KytosTagtypeNotSupported()
-        mock_interface.notify_interface_tags = MagicMock()
+        self.napp.handle_on_interface_tags = MagicMock()
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = mock_interface
         payload = {
@@ -1759,7 +1759,7 @@ class TestMain:
         url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
         response = await self.api_client.post(url, json=payload)
         assert response.status_code == 400
-        assert mock_interface.notify_interface_tags.call_count == 0
+        assert self.napp.handle_on_interface_tags.call_count == 0
 
     async def test_delete_tag_range(self, event_loop):
         """Test delete_tag_range"""
@@ -1769,6 +1769,7 @@ class TestMain:
         mock_switch = get_switch_mock(dpid)
         mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
         mock_interface.remove_tag_ranges = MagicMock()
+        self.napp.handle_on_interface_tags = MagicMock()
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = mock_interface
         url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1630,14 +1630,14 @@ class TestMain:
         assert mock_notify_link_status_change.call_count == 2
         mock_notify_topology_update.assert_called_once()
 
-    def test_mapp_singular_values(self):
-        """Test mapp_singular_values"""
+    def test_map_singular_values(self):
+        """Test map_singular_values"""
         mock_tag = 201
-        result = self.napp.mapp_singular_values(mock_tag)
+        result = self.napp.map_singular_values(mock_tag)
         assert result == [201, 201]
 
         mock_tag = [201]
-        result = self.napp.mapp_singular_values(mock_tag)
+        result = self.napp.map_singular_values(mock_tag)
         assert result == [201, 201]
 
     def test_get_tag_ranges(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,8 +9,11 @@ from unittest.mock import MagicMock, create_autospec, patch, call
 from kytos.core.common import EntityStatus
 from kytos.core.helpers import now
 from kytos.core.events import KytosEvent
+from kytos.core.exceptions import (KytosSetTagRangeError,
+                                   KytosTagtypeNotSupported)
 from kytos.core.interface import Interface
 from kytos.core.link import Link
+from kytos.core.rest_api import HTTPException
 from kytos.core.switch import Switch
 from kytos.lib.helpers import (get_interface_mock, get_link_mock,
                                get_controller_mock, get_switch_mock,
@@ -65,7 +68,6 @@ class TestMain:
         expected_events = [
             'kytos/core.shutdown',
             'kytos/core.shutdown.kytos/topology',
-            'kytos/.*.link_available_tags',
             '.*.topo_controller.upsert_switch',
             '.*.of_lldp.network_status.updated',
             '.*.interface.is.nni',
@@ -82,6 +84,7 @@ class TestMain:
             'kytos/topology.notify_link_up_if_status',
             'topology.interruption.start',
             'topology.interruption.end',
+            'kytos/core.interface_tags',
         ]
         actual_events = self.napp.listeners()
         assert sorted(expected_events) == sorted(actual_events)
@@ -289,7 +292,7 @@ class TestMain:
         error = 'Error loading link 1: xpto'
         mock_log.error.assert_called_with(error)
 
-    @patch('napps.kytos.topology.main.Main.load_interfaces_available_tags')
+    @patch('napps.kytos.topology.main.Main.load_interfaces_tags_values')
     @patch('napps.kytos.topology.main.KytosEvent')
     def test_load_switch(self, *args):
         """Test _load_switch."""
@@ -417,56 +420,40 @@ class TestMain:
         assert interface.uni
         assert not interface.nni
 
-    def test_interfaces_available_tags(self):
-        """Test load_interfaces_available_tags."""
+    def test_load_interfaces_tags_values(self):
+        """Test load_interfaces_tags_values."""
         dpid_a = "00:00:00:00:00:00:00:01"
         mock_switch_a = get_switch_mock(dpid_a, 0x04)
         mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
         mock_interface_a.id = dpid_a + ':1'
         mock_switch_a.interfaces = {1: mock_interface_a}
-        tags = [1, 2, 3]
-        interface_details = [{"id": mock_interface_a.id,
-                             "available_vlans": tags}]
-        self.napp.load_interfaces_available_tags(mock_switch_a,
-                                                 interface_details)
-        mock_interface_a.set_available_tags.assert_called_once_with(tags)
+        ava_tags = {'vlan': [[10, 4095]]}
+        tag_ranges = {'vlan': [[5, 4095]]}
+        interface_details = [{
+            "id": mock_interface_a.id,
+            "available_tags": ava_tags,
+            "tag_ranges": tag_ranges
+        }]
+        self.napp.load_interfaces_tags_values(mock_switch_a,
+                                              interface_details)
+        set_method = mock_interface_a.set_available_tags_tag_ranges
+        set_method.assert_called_once_with(ava_tags, tag_ranges)
 
-    def test_handle_on_link_available_tags(self):
-        """test_handle_on_link_available_tags."""
+    def test_handle_on_interface_tags(self):
+        """test_handle_on_interface_tags."""
         dpid_a = "00:00:00:00:00:00:00:01"
-        dpid_b = "00:00:00:00:00:00:00:02"
-        tag = MagicMock()
-        tag.value = 1
-        tags = [tag]
-        link_mock = MagicMock()
+        available_tags = {'vlan': [[200, 3000]]}
+        tag_ranges = {'vlan': [[20, 20], [200, 3000]]}
         mock_switch_a = get_switch_mock(dpid_a, 0x04)
         mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
-        mock_interface_a.available_tags = tags
-        mock_switch_b = get_switch_mock(dpid_b, 0x04)
-        mock_interface_b = get_interface_mock('s2-eth1', 1, mock_switch_b)
-        mock_interface_b.available_tags = tags
-        link_id = '4d42dc08522'
-        link_mock.id = link_id
-        link_mock.endpoint_a = mock_interface_a
-        link_mock.endpoint_b = mock_interface_b
-
-        self.napp.links[link_id] = link_mock
-        self.napp.handle_on_link_available_tags(link_mock)
-        bulk_upsert = self.napp.topo_controller.bulk_upsert_interface_details
-        bulk_upsert.assert_called_once_with(
-            [
-                (
-                    "00:00:00:00:00:00:00:01:1",
-                    {"_id": "00:00:00:00:00:00:00:01:1",
-                     "available_vlans": [1]},
-                ),
-                (
-                    "00:00:00:00:00:00:00:02:1",
-                    {"_id": "00:00:00:00:00:00:00:02:1",
-                     "available_vlans": [1]},
-                ),
-            ]
-        )
+        mock_interface_a.available_tags = available_tags
+        mock_interface_a.tag_ranges = tag_ranges
+        self.napp.handle_on_interface_tags(mock_interface_a)
+        tp_controller = self.napp.topo_controller
+        args = tp_controller.upsert_interface_details.call_args[0]
+        assert args[0] == '00:00:00:00:00:00:00:01:1'
+        assert args[1] == {'vlan': [[200, 3000]]}
+        assert args[2] == {'vlan': [[20, 20], [200, 3000]]}
 
     def test_load_link(self):
         """Test _load_link."""
@@ -1642,3 +1629,180 @@ class TestMain:
         )
         assert mock_notify_link_status_change.call_count == 2
         mock_notify_topology_update.assert_called_once()
+
+    def test_mapp_singular_values(self):
+        """Test mapp_singular_values"""
+        mock_tag = 201
+        result = self.napp.mapp_singular_values(mock_tag)
+        assert result == [201, 201]
+
+        mock_tag = [201]
+        result = self.napp.mapp_singular_values(mock_tag)
+        assert result == [201, 201]
+
+    def test_get_tag_ranges(self):
+        """Test _get_tag_ranges"""
+        mock_content = {'tag_ranges': [100, [150], [200, 3000]]}
+        result = self.napp._get_tag_ranges(mock_content)
+        assert result == [[100, 100], [150, 150], [200, 3000]]
+
+        # Empty
+        mock_content = {'tag_ranges': []}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+        # Range not ordered
+        mock_content = {'tag_ranges': [[20, 19]]}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+        # Ranges not ordered
+        mock_content = {'tag_ranges': [[20, 50], [30, 3000]]}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+        # Unnecessary partition
+        mock_content = {'tag_ranges': [[20, 50], [51, 3000]]}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+        # Repeated tag
+        mock_content = {'tag_ranges': [[20, 50], [50, 3000]]}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+        # Over 4095
+        mock_content = {'tag_ranges': [[20, 50], [50, 4096]]}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+        # Under 1
+        mock_content = {'tag_ranges': [[0, 50], [50, 3000]]}
+        with pytest.raises(HTTPException):
+            self.napp._get_tag_ranges(mock_content)
+
+    async def test_set_tag_range(self, event_loop):
+        """Test set_tag_range"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.set_tag_ranges = MagicMock()
+        mock_interface.notify_interface_tags = MagicMock()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = mock_interface
+        payload = {
+            "tag_type": "vlan",
+            "tag_ranges": [[20, 20], [200, 3000]]
+        }
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.post(url, json=payload)
+        assert response.status_code == 200
+
+        args = mock_interface.set_tag_ranges.call_args[0]
+        assert args[0] == payload['tag_ranges']
+        assert args[1] == payload['tag_type']
+        assert mock_interface.notify_interface_tags.call_count == 1
+
+    async def test_set_tag_range_not_found(self, event_loop):
+        """Test set_tag_range. Not found"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = None
+        payload = {
+            "tag_type": "vlan",
+            "tag_ranges": [[20, 20], [200, 3000]]
+        }
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.post(url, json=payload)
+        assert response.status_code == 404
+
+    async def test_set_tag_range_tag_error(self, event_loop):
+        """Test set_tag_range TagRangeError"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.set_tag_ranges = MagicMock()
+        mock_interface.set_tag_ranges.side_effect = KytosSetTagRangeError()
+        mock_interface.notify_interface_tags = MagicMock()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = mock_interface
+        payload = {
+            "tag_type": "vlan",
+            "tag_ranges": [[20, 20], [200, 3000]]
+        }
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.post(url, json=payload)
+        assert response.status_code == 400
+        assert mock_interface.notify_interface_tags.call_count == 0
+
+    async def test_set_tag_range_type_error(self, event_loop):
+        """Test set_tag_range TagRangeError"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.set_tag_ranges = MagicMock()
+        mock_interface.set_tag_ranges.side_effect = KytosTagtypeNotSupported()
+        mock_interface.notify_interface_tags = MagicMock()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = mock_interface
+        payload = {
+            "tag_type": "wrong_tag_type",
+            "tag_ranges": [[20, 20], [200, 3000]]
+        }
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.post(url, json=payload)
+        assert response.status_code == 400
+        assert mock_interface.notify_interface_tags.call_count == 0
+
+    async def test_delete_tag_range(self, event_loop):
+        """Test delete_tag_range"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.remove_tag_ranges = MagicMock()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = mock_interface
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.delete(url)
+        assert response.status_code == 200
+        assert mock_interface.remove_tag_ranges.call_count == 1
+
+    async def test_delete_tag_range_not_found(self, event_loop):
+        """Test delete_tag_range. Not found"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.remove_tag_ranges = MagicMock()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = None
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.delete(url)
+        assert response.status_code == 404
+        assert mock_interface.remove_tag_ranges.call_count == 0
+
+    async def test_delete_tag_range_type_error(self, event_loop):
+        """Test delete_tag_range TagRangeError"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.remove_tag_ranges = MagicMock()
+        remove_tag = mock_interface.remove_tag_ranges
+        remove_tag.side_effect = KytosTagtypeNotSupported()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = mock_interface
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
+        response = await self.api_client.delete(url)
+        assert response.status_code == 400

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -3,8 +3,6 @@
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from pymongo.operations import UpdateOne
-
 from napps.kytos.topology.controllers import TopoController
 from napps.kytos.topology.db.models import LinkDoc, SwitchDoc
 
@@ -193,19 +191,19 @@ class TestTopoController(TestCase):  # pylint: disable=too-many-public-methods
             [{"$match": {"_id": {"$in": interfaces_ids}}}]
         )
 
-    def test_bulk_upsert_interface_details(self) -> None:
-        """test_bulk_upsert_interface_details."""
-        ids_details = [
-            ("1", {"_id": "1", "available_vlans": [1]}),
-            ("2", {"_id": "2", "available_vlans": [2]}),
-        ]
-        self.topo.bulk_upsert_interface_details(ids_details)
-
-        self.topo.db_client.start_session.assert_called()
-        arg1 = self.topo.db.interface_details.bulk_write.call_args[0]
-        assert len(arg1[0]) == len(ids_details)
-        for item in arg1[0]:
-            assert isinstance(item, UpdateOne)
+    def test_upsert_interface_details(self) -> None:
+        """test_upsert_interface_details."""
+        id_ = "intf_id"
+        available_tags = {'vlan': [[10, 4095]]}
+        tag_ranges = {'vlan': [[5, 4095]]}
+        self.topo.upsert_interface_details(
+            id_, available_tags, tag_ranges
+        )
+        arg = self.topo.db.interface_details.find_one_and_update.call_args[0]
+        assert arg[0] == {"_id": id_}
+        assert arg[1]["$set"]["_id"] == id_
+        assert arg[1]["$set"]["tag_ranges"] == tag_ranges
+        assert arg[1]["$set"]["available_tags"] == available_tags
 
     def test_upsert_switch(self) -> None:
         """test_upsert_switch."""


### PR DESCRIPTION
Closes #157 

### Summary

Changed DB `interface_details` to:
```
  {
    _id: '00:00:00:00:00:00:00:02:2',
    available_vlans: { '1': [ [ 1, 499 ], [ 501, 4095 ] ] },
    id: '00:00:00:00:00:00:00:02:2',
    inserted_at: ISODate("2023-08-28T17:05:42.238Z"),
    tag_ranges: { '1': null }
  },
```
Added API requests to replace `vlan_pool` settings
- Added request DELETE `v3/interfaces/{interface_id}/tag_ranges` with accepted parameter `tag_type`.
- Added request POST `v3/interfaces/{interface_id}/tag_ranges`. Body accepted example `{"1": [[100, 4000]]}`.
- Adapted NApp from `tag_type` interger to string

### Local Tests

Sent requests with the added URLs
Unit tests added

### End-to-End Tests
This PR is part of the epic [epic_topology_vlanpool](https://github.com/search?q=org%3Akytos-ng+is%3Aissue+label%3Aepic_topology_vlanpool). 
E2E tests are passing, [comment](https://github.com/kytos-ng/topology/pull/160#issuecomment-1714155360). 