### PR TITLE
feature: Added get endpoints for Interface tag ranges

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Added
 =====
 - Added endpoint ``POST v3/interfaces/{interface_id}/tag_ranges`` to set ``tag_ranges`` to interfaces.
 - Added endpoint ``DELETE v3/interfaces/{interface_id}/tag_ranges`` to delete ``tag_ranges`` from interfaces.
+- Added endpoint ``GET v3/interfaces/{interface_id}/tag_ranges`` to get ``available_tags`` and ``tag_ranges`` from an interface.
+- Added endpoint ``GET v3/interfaces/tag_ranges`` to get ``available_tags`` and ``tag_ranges`` from all interfaces.
 - Added ``Tag_ranges`` documentation to openapi.yml
 - Added API request POST and DELETE to modify ``Interface.tag_ranges``
 - Added listener for ``kytos/core.interface_tags`` event to save any changes made to ``Interface`` attributes ``tag_ranges`` and ``available_tags``

--- a/main.py
+++ b/main.py
@@ -579,10 +579,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @validate_openapi(spec)
     def get_all_tag_ranges(self, _: Request) -> JSONResponse:
         """Get all tag_ranges and available_tags from interfaces"""
-        result = defaultdict(dict)
-        for switch_id, switch in self.controller.switches.copy().items():
-            for intf_id, interface in switch.interfaces.copy().items():
-                result[switch_id][intf_id] = {
+        result = {}
+        for switch in self.controller.switches.copy().values():
+            for interface in switch.interfaces.copy().values():
+                result[interface.id] = {
                     "available_tags": interface.available_tags,
                     "tag_ranges": interface.tag_ranges
                 }

--- a/main.py
+++ b/main.py
@@ -577,12 +577,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     @rest('v3/interfaces/tag_ranges', methods=['GET'])
     @validate_openapi(spec)
-    def get_all_tag_ranges(self, _):
+    def get_all_tag_ranges(self, _: Request) -> JSONResponse:
         """Get all tag_ranges and available_tags from interfaces"""
-        result = {}
-        for switch_id, switch in self.controller.switches.items():
-            result[switch_id] = {}
-            for intf_id, interface in switch.interfaces.items():
+        result = defaultdict(dict)
+        for switch_id, switch in self.controller.switches.copy().items():
+            for intf_id, interface in switch.interfaces.copy().items():
                 result[switch_id][intf_id] = {
                     "available_tags": interface.available_tags,
                     "tag_ranges": interface.tag_ranges

--- a/main.py
+++ b/main.py
@@ -575,6 +575,36 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(400, detail=detail)
         return JSONResponse("Operation Successful", status_code=200)
 
+    @rest('v3/interfaces/tag_ranges', methods=['GET'])
+    @validate_openapi(spec)
+    def get_all_tag_ranges(self, _):
+        """Get all tag_ranges and available_tags from interfaces"""
+        result = {}
+        for switch_id, switch in self.controller.switches.items():
+            result[switch_id] = {}
+            for intf_id, interface in switch.interfaces.items():
+                result[switch_id][intf_id] = {
+                    "available_tags": interface.available_tags,
+                    "tag_ranges": interface.tag_ranges
+                }
+        return JSONResponse(result, status_code=200)
+
+    @rest('v3/interfaces/{interface_id}/tag_ranges', methods=['GET'])
+    @validate_openapi(spec)
+    def get_tag_ranges_by_intf(self, request: Request) -> JSONResponse:
+        """Get tag_ranges and available_tags an interface"""
+        interface_id = request.path_params["interface_id"]
+        interface = self.controller.get_interface_by_id(interface_id)
+        if not interface:
+            raise HTTPException(404, detail="Interface not found")
+        result = {
+            interface_id: {
+                "available_tags": interface.available_tags,
+                "tag_ranges": interface.tag_ranges
+            }
+        }
+        return JSONResponse(result, status_code=200)
+
     # Link related methods
     @rest('v3/links')
     def get_links(self, _request: Request) -> JSONResponse:

--- a/openapi.yml
+++ b/openapi.yml
@@ -409,7 +409,35 @@ paths:
               schema:
                 type: string
                 example: Switch not found
+  /v3/interfaces/tag_ranges:
+    get:
+      summary: Get tag_ranges and available_tags from all interface
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
   /v3/interfaces/{interface_id}/tag_ranges:
+    get:
+      summary: Get tag_ranges and available_tags from an interface
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: The interface ID
+          in: path
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Interface not found
     post:
       summary: Set tag_range from an interface
       parameters:

--- a/openapi.yml
+++ b/openapi.yml
@@ -419,6 +419,22 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  switch_id:
+                    type: object
+                    properties:
+                      interface_index:
+                        type: object
+                        properties:
+                          tag_ranges:
+                            $ref: "#/components/schemas/InterfaceRanges"
+                          available_tags:
+                            $ref: "#/components/schemas/InterfaceRanges"
+              example: 
+                "00:00:00:00:00:00:00:01":
+                  "2":
+                    "available_tags": [[1, 4096]]
+                    "tag_ranges": [[1,4096]]
   /v3/interfaces/{interface_id}/tag_ranges:
     get:
       summary: Get tag_ranges and available_tags from an interface
@@ -436,6 +452,18 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  interface_id:
+                    type: object
+                    properties:
+                      tag_ranges:
+                        $ref: "#/components/schemas/InterfaceRanges"
+                      available_tags:
+                        $ref: "#/components/schemas/InterfaceRanges"
+              example: 
+                "00:00:00:00:00:00:00:01:2":
+                  "available_tags": [[1, 4096]]
+                  "tag_ranges": [[1,4096]]
         '404':
           description: Interface not found
     post:
@@ -781,3 +809,14 @@ components:
               - type: array
               - type: integer
           example: [[1, 500], 2096, [3001]]
+    InterfaceRanges:
+      type: object
+      properties:
+        vlan:
+          type: array
+          items:
+            type: array
+            items:
+              type: integer          
+            minItems: 2
+            maxItems: 2

--- a/openapi.yml
+++ b/openapi.yml
@@ -420,21 +420,17 @@ paths:
               schema:
                 type: object
                 properties:
-                  switch_id:
+                  interface_id:
                     type: object
                     properties:
-                      interface_index:
-                        type: object
-                        properties:
-                          tag_ranges:
-                            $ref: "#/components/schemas/InterfaceRanges"
-                          available_tags:
-                            $ref: "#/components/schemas/InterfaceRanges"
+                      tag_ranges:
+                        $ref: '#/components/schemas/InterfaceRanges'
+                      available_tags:
+                        $ref: '#/components/schemas/InterfaceRanges'
               example: 
-                "00:00:00:00:00:00:00:01":
-                  "2":
-                    "available_tags": [[1, 4096]]
-                    "tag_ranges": [[1,4096]]
+                "00:00:00:00:00:00:00:01:2":
+                  "available_tags": [[1, 4096]]
+                  "tag_ranges": [[1,4096]]
   /v3/interfaces/{interface_id}/tag_ranges:
     get:
       summary: Get tag_ranges and available_tags from an interface
@@ -457,9 +453,9 @@ paths:
                     type: object
                     properties:
                       tag_ranges:
-                        $ref: "#/components/schemas/InterfaceRanges"
+                        $ref: '#/components/schemas/InterfaceRanges'
                       available_tags:
-                        $ref: "#/components/schemas/InterfaceRanges"
+                        $ref: '#/components/schemas/InterfaceRanges'
               example: 
                 "00:00:00:00:00:00:00:01:2":
                   "available_tags": [[1, 4096]]
@@ -809,7 +805,7 @@ components:
               - type: array
               - type: integer
           example: [[1, 500], 2096, [3001]]
-    InterfaceRanges:
+    InterfaceRanges: # Can be referenced via '#/components/schemas/InterfaceRanges'
       type: object
       properties:
         vlan:

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@epic/vlan_pool#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
 -e .

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_pool#egg=kytos[dev]
 -e .

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1821,11 +1821,9 @@ class TestMain:
         self.napp.controller.switches = {dpid: switch}
         url = f"{self.base_endpoint}/interfaces/tag_ranges"
         response = await self.api_client.get(url)
-        expected = {dpid: {
-            '1': {
-                'available_tags': tags,
-                'tag_ranges': tags
-            }
+        expected = {dpid + ":1": {
+            'available_tags': tags,
+            'tag_ranges': tags
         }}
         assert response.status_code == 200
         assert response.json() == expected

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1807,3 +1807,57 @@ class TestMain:
         url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"
         response = await self.api_client.delete(url)
         assert response.status_code == 400
+
+    async def test_get_all_tag_ranges(self, event_loop):
+        """Test get_all_tag_ranges"""
+        self.napp.controller.loop = event_loop
+        dpid = '00:00:00:00:00:00:00:01'
+        switch = get_switch_mock(dpid)
+        interface = get_interface_mock('s1-eth1', 1, switch)
+        tags = {'vlan': [[1, 4095]]}
+        interface.tag_ranges = tags
+        interface.available_tags = tags
+        switch.interfaces = {1: interface}
+        self.napp.controller.switches = {dpid: switch}
+        url = f"{self.base_endpoint}/interfaces/tag_ranges"
+        response = await self.api_client.get(url)
+        expected = {dpid: {
+            '1': {
+                'available_tags': tags,
+                'tag_ranges': tags
+            }
+        }}
+        assert response.status_code == 200
+        assert response.json() == expected
+
+    async def test_get_tag_ranges_by_intf(self, event_loop):
+        """Test get_tag_ranges_by_intf"""
+        self.napp.controller.loop = event_loop
+        dpid = '00:00:00:00:00:00:00:01'
+        switch = get_switch_mock(dpid)
+        interface = get_interface_mock('s1-eth1', 1, switch)
+        tags = {'vlan': [[1, 4095]]}
+        interface.tag_ranges = tags
+        interface.available_tags = tags
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = interface
+        url = f"{self.base_endpoint}/interfaces/{dpid}:1/tag_ranges"
+        response = await self.api_client.get(url)
+        expected = {
+            '00:00:00:00:00:00:00:01:1': {
+                "available_tags": tags,
+                "tag_ranges": tags
+            }
+        }
+        assert response.status_code == 200
+        assert response.json() == expected
+
+    async def test_get_tag_ranges_by_intf_error(self, event_loop):
+        """Test get_tag_ranges_by_intf with NotFound"""
+        self.napp.controller.loop = event_loop
+        dpid = '00:00:00:00:00:00:00:01'
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = None
+        url = f"{self.base_endpoint}/interfaces/{dpid}:1/tag_ranges"
+        response = await self.api_client.get(url)
+        assert response.status_code == 404


### PR DESCRIPTION
Closes #162 

### Summary

This is based on the branch `epic/vlan_pool` which is not going to be modified.
Added endpoints:
- `GET v3/interfaces/{interface_id}/tag_ranges`
- `GET v3/interfaces/tag_ranges`

### Local Tests
Called these new API endpoints
Added unit tests

### End-to-End Tests
N/A

Note:
Tox is passing