### PR TITLE
backport: `kytos/.*.uni_available_tags` to update UNI tags in interfaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,13 @@ Security
 Changed
 =======
 
+[2023.1.1] - 2023-10-12
+********************************
+
+Added
+=====
+- Added subscription to ``kytos/.*.uni_available_tags`` event to save ``Interface.available_tags`` to DB when a UNI uses a tag.
+
 [2023.1.0] - 2023-06-26
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Subscribed
 - ``kytos/.*.liveness.(up|down)``
 - ``kytos/.*.liveness.disabled``
 - ``kytos/topology.notify_link_up_if_status``
+- ``kytos/.*.uni_available_tags``
 
 
 Published

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2023.1.0",
+  "version": "2023.1.1",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -659,7 +659,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if not uni.user_tag:
             return
         intf = uni.interface
-        with self._intf_locks[intf.id]:
+        with self._intfs_lock[intf.id]:
             if (
                 intf.id in self._intfs_tags_updated_at
                 and self._intfs_tags_updated_at[intf.id] > event.timestamp

--- a/main.py
+++ b/main.py
@@ -656,8 +656,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def on_uni_available_tags(self, event):
         """Handle on_uni_available_tags"""
         uni = event.content.get("uni")
-        if not uni.user_tag:
-            return
         intf = uni.interface
         with self._intfs_lock[intf.id]:
             if (

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -153,3 +153,57 @@ Modified 0 switches objects
 ```
 
 </details>
+
+
+<details><summary><h3> <code>UNI tag allocation</code> from evcs to interface_details collections </h3></summary>
+
+[`uni_tag_allocation.py`](./uni_tag_allocation.py) is a script to allocate UNI tags from evcs collection
+
+
+#### Pre-requisites
+- Make sure MongoDB replica set is up and running.
+- Export the following MongnoDB variables accordingly in case your running outside of a container
+
+```
+export MONGO_USERNAME=
+export MONGO_PASSWORD=
+export MONGO_DBNAME=napps
+export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
+```
+
+- The following `CMD` commands are available:
+
+```
+aggregate_uni_tags
+update_database
+```
+
+#### Examples
+
+- Previewing aggregated interfaces which that are going to have their available_vlans changed:
+
+```
+❯ CMD=aggregate_uni_tags python scripts/uni_tag_allocation.py
+```
+
+Response example:
+
+```
+Interfaces that probably need their available_vlans modified.
+00:00:00:00:00:00:00:01:1: [100, 200]
+00:00:00:00:00:00:00:02:1: [100]
+00:00:00:00:00:00:00:02:2: [100]
+```
+
+- Update outdated available_vlans from interfaces. Create a new document if neccessary
+
+```
+❯ CMD=update_database python scripts/uni_tag_allocation.py 
+```
+
+Response example:
+```
+1 documents modified. 2 documents inserted
+```
+
+</details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -190,7 +190,7 @@ Response example:
 
 ```
 No conflicts detected between NNIs and UNIs
-Interfaces that probably need their available_vlans modified.
+Interfaces that are used by UNIs and their tag values.
 00:00:00:00:00:00:00:01:1: [100, 200]
 00:00:00:00:00:00:00:02:1: [100]
 00:00:00:00:00:00:00:02:2: [100]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -189,10 +189,19 @@ update_database
 Response example:
 
 ```
+No conflicts detected between NNIs and UNIs
 Interfaces that probably need their available_vlans modified.
 00:00:00:00:00:00:00:01:1: [100, 200]
 00:00:00:00:00:00:00:02:1: [100]
 00:00:00:00:00:00:00:02:2: [100]
+```
+
+Since UNI tags allocation was not supported, the possible conflicts with NNI tags are detected:
+
+```
+There are some conflicts between NNIs and UNIs tag values:
+Tag 1 conflict in UNI_A, interface 00:00:00:00:00:00:00:01:3
+Tag 1 conflict in UNI_A, interface 00:00:00:00:00:00:00:01:4
 ```
 
 - Update outdated available_vlans from interfaces. Create a new document if neccessary
@@ -204,6 +213,16 @@ Interfaces that probably need their available_vlans modified.
 Response example:
 ```
 1 documents modified. 2 documents inserted
+```
+
+If a conflict with NNI tags is detected, there will not be any changes to the database:
+
+```
+Conflicts between NNIs and UNIs detected:
+Tag 1 conflict in UNI_A from EVC c23d595655dd47, interface 00:00:00:00:00:00:00:01:3
+Tag 1 conflict in UNI_A from EVC 3af68f6804f144, interface 00:00:00:00:00:00:00:01:4
+
+Exiting
 ```
 
 </details>

--- a/scripts/uni_tag_allocation.py
+++ b/scripts/uni_tag_allocation.py
@@ -1,15 +1,8 @@
 import os
 import sys
 import datetime
-from pymongo.operations import UpdateMany
 from kytos.core.db import Mongo
 from collections import defaultdict
-
-TAG_TYPE = {
-    1: "vlan",
-    2: "vlan_qinq",
-    3: "mpls",
-}
 
 def update_database(mongo: Mongo):
     db = mongo.client[mongo.db_name]

--- a/scripts/uni_tag_allocation.py
+++ b/scripts/uni_tag_allocation.py
@@ -7,19 +7,54 @@ from collections import defaultdict
 def update_database(mongo: Mongo):
     db = mongo.client[mongo.db_name]
 
-    circuits = db.evcs.find({},
+    circuits = db.evcs.find(
+        {"archived": False},
+        {"current_path": 1, "failover_path": 1}
+    )
+    errors = ""
+    intf_update = defaultdict(list)
+    intf_path = defaultdict(set)
+    for circuit in circuits:
+        for path in circuit["current_path"]:
+            tag = path["metadata"]["s_vlan"]["value"]
+            intf_a = path["endpoint_a"]["id"]
+            intf_b = path["endpoint_b"]["id"]
+            intf_path[intf_a].add(tag)
+            intf_path[intf_b].add(tag)
+        for path in circuit["failover_path"]:
+            tag = path["metadata"]["s_vlan"]["value"]
+            intf_a = path["endpoint_a"]["id"]
+            intf_b = path["endpoint_b"]["id"]
+            intf_path[intf_a].add(tag)
+            intf_path[intf_b].add(tag)
+
+    circuits = db.evcs.find(
+        {"archived": False},
         {"uni_a": 1, "uni_z": 1}
     )
-    intf_update = defaultdict(list)
     for circuit in circuits:
         tag_a = circuit["uni_a"].get("tag")
         tag_z = circuit["uni_z"].get("tag")
         if tag_a:
             intf_a = circuit["uni_a"]["interface_id"]
-            intf_update[intf_a].append(tag_a["value"])
+            tag_val = tag_a["value"]
+            if tag_val in intf_path[intf_a]:
+                _id = circuit["_id"]
+                errors += f"Tag {tag_val} conflict in UNI_A from EVC {_id}, interface {intf_a}\n"
+            intf_update[intf_a].append(tag_val)
         if tag_z:
             intf_z = circuit["uni_z"]["interface_id"]
-            intf_update[intf_z].append(tag_z["value"])
+            tag_val = tag_z["value"]
+            if tag_val in intf_path[intf_z]:
+                _id = circuit["_id"]
+                errors += f"Tag {tag_val} conflict in UNI_Z from EVC {_id}, interface {intf_z}\n"
+            intf_update[intf_z].append(tag_val)
+
+    if errors:
+        print("Conflicts between NNIs and UNIs detected:")
+        print(errors)
+        print("Exiting")
+        sys.exit(1)
 
     modi_count = 0
     intf_details = db.interface_details.find()
@@ -57,27 +92,57 @@ def aggregate_uni_tags(mongo: Mongo):
     db = mongo.client[mongo.db_name]
 
     circuits = db.evcs.find(
-        {},
-        {
-            "uni_a": 1,
-            "uni_z": 1
-        }
+        {"archived": False},
+        {"current_path": 1, "failover_path": 1}
     )
+    errors = ""
     intf_update = defaultdict(list)
+    intf_path = defaultdict(set)
+    for circuit in circuits:
+        for path in circuit["current_path"]:
+            tag = path["metadata"]["s_vlan"]["value"]
+            intf_a = path["endpoint_a"]["id"]
+            intf_b = path["endpoint_b"]["id"]
+            intf_path[intf_a].add(tag)
+            intf_path[intf_b].add(tag)
+        for path in circuit["failover_path"]:
+            tag = path["metadata"]["s_vlan"]["value"]
+            intf_a = path["endpoint_a"]["id"]
+            intf_b = path["endpoint_b"]["id"]
+            intf_path[intf_a].add(tag)
+            intf_path[intf_b].add(tag)
+
+    circuits = db.evcs.find(
+        {"archived": False},
+        {"uni_a": 1, "uni_z": 1}
+    )
     for circuit in circuits:
         tag_a = circuit["uni_a"].get("tag")
         tag_z = circuit["uni_z"].get("tag")
         if tag_a:
             intf_a = circuit["uni_a"]["interface_id"]
-            intf_update[intf_a].append(tag_a["value"])
+            tag_val = tag_a["value"]
+            if tag_val in intf_path[intf_a]:
+                _id = circuit["_id"]
+                errors += f"Tag {tag_val} conflict in UNI_A from EVC {_id}, interface {intf_a}\n"
+            intf_update[intf_a].append(tag_val)
         if tag_z:
             intf_z = circuit["uni_z"]["interface_id"]
-            intf_update[intf_z].append(tag_z["value"])
+            tag_val = tag_z["value"]
+            if tag_val in intf_path[intf_z]:
+                _id = circuit["_id"]
+                errors += f"Tag {tag_val} conflict in UNI_Z from EVC {_id}, interface {intf_z}\n"
+            intf_update[intf_z].append(tag_val)
+    if errors:
+        print("There are some conflicts between NNIs and UNIs tag values:")
+        print(errors)
+    else:
+        print("No conflicts detected between NNIs and UNIs")
 
     if not intf_update:
         return
 
-    print("Interfaces that probably need their available_vlans modified.")
+    print("Interfaces that are used by UNIs and their tag values.")
     for intf in intf_update:
         print(f"{intf}: {intf_update[intf]}")
 

--- a/scripts/uni_tag_allocation.py
+++ b/scripts/uni_tag_allocation.py
@@ -1,0 +1,104 @@
+import os
+import sys
+import datetime
+from pymongo.operations import UpdateMany
+from kytos.core.db import Mongo
+from collections import defaultdict
+
+TAG_TYPE = {
+    1: "vlan",
+    2: "vlan_qinq",
+    3: "mpls",
+}
+
+def update_database(mongo: Mongo):
+    db = mongo.client[mongo.db_name]
+
+    circuits = db.evcs.find({},
+        {"uni_a": 1, "uni_z": 1}
+    )
+    intf_update = defaultdict(list)
+    for circuit in circuits:
+        tag_a = circuit["uni_a"].get("tag")
+        tag_z = circuit["uni_z"].get("tag")
+        if tag_a:
+            intf_a = circuit["uni_a"]["interface_id"]
+            intf_update[intf_a].append(tag_a["value"])
+        if tag_z:
+            intf_z = circuit["uni_z"]["interface_id"]
+            intf_update[intf_z].append(tag_z["value"])
+
+    modi_count = 0
+    intf_details = db.interface_details.find()
+    for document in intf_details:
+        tag_list = intf_update.pop(document["id"], None)
+        if not tag_list:
+            continue
+        result = db.interface_details.update_one(
+            {"id": document["id"]},
+            {"$pull": {"available_vlans": {"$in": tag_list}}}
+        )
+        modi_count += result.modified_count
+
+    added_count = 0
+    for intf_id, tag_list in intf_update.items():
+        tag_list = set(tag_list)
+        new_list = []
+        for tag in range(1, 4096):
+            if tag in tag_list:
+                continue
+            new_list.append(tag)
+        utc_now = datetime.datetime.utcnow()
+        result = db.interface_details.insert_one({
+            "_id": intf_id,
+            "id": intf_id,
+            "inserted_at": utc_now,
+            "updated_at": utc_now,
+            "available_vlans": new_list,
+        })
+        added_count += 1
+    
+    print(f"{modi_count} documents modified. {added_count} documents inserted")
+
+def aggregate_uni_tags(mongo: Mongo):
+    db = mongo.client[mongo.db_name]
+
+    circuits = db.evcs.find(
+        {},
+        {
+            "uni_a": 1,
+            "uni_z": 1
+        }
+    )
+    intf_update = defaultdict(list)
+    for circuit in circuits:
+        tag_a = circuit["uni_a"].get("tag")
+        tag_z = circuit["uni_z"].get("tag")
+        if tag_a:
+            intf_a = circuit["uni_a"]["interface_id"]
+            intf_update[intf_a].append(tag_a["value"])
+        if tag_z:
+            intf_z = circuit["uni_z"]["interface_id"]
+            intf_update[intf_z].append(tag_z["value"])
+
+    if not intf_update:
+        return
+
+    print("Interfaces that probably need their available_vlans modified.")
+    for intf in intf_update:
+        print(f"{intf}: {intf_update[intf]}")
+
+if __name__ == "__main__":
+    mongo = Mongo()
+    cmds = {
+        "aggregate_uni_tags": aggregate_uni_tags,
+        "update_database": update_database,
+    }
+    try:
+        cmd = os.environ["CMD"]
+        cmds[cmd](mongo)
+    except KeyError:
+        print(
+            f"Please set the 'CMD' env var. \nIt has to be one of these: {list(cmds.keys())}"
+        )
+        sys.exit(1)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -57,6 +57,7 @@ class TestMain:
             'kytos/topology.notify_link_up_if_status',
             'topology.interruption.start',
             'topology.interruption.end',
+            'kytos/.*.uni_available_tags',
         ]
         assert sorted(expected_events) == sorted(actual_events)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -82,6 +82,7 @@ class TestMain:
             'kytos/topology.notify_link_up_if_status',
             'topology.interruption.start',
             'topology.interruption.end',
+            'kytos/.*.uni_available_tags',
         ]
         actual_events = self.napp.listeners()
         assert sorted(expected_events) == sorted(actual_events)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, create_autospec, patch, call
 from kytos.core.common import EntityStatus
 from kytos.core.helpers import now
 from kytos.core.events import KytosEvent
-from kytos.core.interface import Interface
+from kytos.core.interface import Interface, UNI, TAG
 from kytos.core.link import Link
 from kytos.core.switch import Switch
 from kytos.lib.helpers import (get_interface_mock, get_link_mock,
@@ -1643,3 +1643,19 @@ class TestMain:
         )
         assert mock_notify_link_status_change.call_count == 2
         mock_notify_topology_update.assert_called_once()
+
+    def test_handle_on_uni_available_tags(self):
+        """Test handle_on_uni_available_tags"""
+        uni = create_autospec(UNI)
+        uni.interface = create_autospec(Interface)
+        uni.interface.available_tags = [TAG(1, 100)]
+        id_ = uni.interface.id
+        expected = [
+            (id_, {"_id": id_, "available_vlans": [100]})
+        ]
+        self.napp.handle_on_uni_available_tags(uni)
+        controller = self.napp.topo_controller
+        calls = controller.bulk_upsert_interface_details.call_count
+        assert calls == 1
+        args = controller.bulk_upsert_interface_details.call_args[0]
+        assert args[0] == expected


### PR DESCRIPTION
Closes #165 

### Summary

The base branch is `base/2023.1.0`, It is what we have on [releases](https://github.com/kytos-ng/topology/releases).
Added `kytos/.*.uni_available_tags` so `Interface.available_tags` is updated in the DB when a UNI tag is allocated

### Local Tests

Added uni tests
Created EVCs and see allocated vlan from interfaces.

### End-To-End Tests
Results in `mef_eline` [PR](https://github.com/kytos-ng/mef_eline/pull/381)