### PR TITLE
Moved `_get_tag_ranges()` to kytos/core

### DIFF
--- a/main.py
+++ b/main.py
@@ -505,8 +505,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             interface.set_tag_ranges(ranges, tag_type)
             self.handle_on_interface_tags(interface)
         except KytosTagError as err:
-            detail = f"Error when setting tag ranges: {err}"
-            raise HTTPException(400, detail=detail)
+            raise HTTPException(400, detail=str(err))
         return JSONResponse("Operation Successful", status_code=200)
 
     @rest('v3/interfaces/{interface_id}/tag_ranges', methods=['DELETE'])
@@ -523,8 +522,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             interface.remove_tag_ranges(tag_type)
             self.handle_on_interface_tags(interface)
         except KytosTagError as err:
-            detail = f"Error with tag_type. {err}"
-            raise HTTPException(400, detail=detail)
+            raise HTTPException(400, detail=str(err))
         return JSONResponse("Operation Successful", status_code=200)
 
     @rest('v3/interfaces/tag_ranges', methods=['GET'])

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.common import EntityStatus
-from kytos.core.exceptions import (KytosLinkCreationError,
+from kytos.core.exceptions import (KytosInvalidRanges, KytosLinkCreationError,
                                    KytosSetTagRangeError,
                                    KytosTagtypeNotSupported)
 from kytos.core.helpers import listen_to, load_spec, now, validate_openapi
@@ -21,6 +21,7 @@ from kytos.core.link import Link
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  content_type_json_or_415, get_json_or_400)
 from kytos.core.switch import Switch
+from kytos.core.tag_ranges import get_tag_ranges
 from napps.kytos.topology import settings
 
 from .controllers import TopoController
@@ -486,54 +487,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_metadata_changes(interface, 'removed')
         return JSONResponse("Operation successful")
 
-    @staticmethod
-    def map_singular_values(tag_range):
-        """Change integer or singular interger list to
-        list[int, int] when necessary"""
-        if isinstance(tag_range, int):
-            tag_range = [tag_range] * 2
-        elif len(tag_range) == 1:
-            tag_range = [tag_range[0]] * 2
-        return tag_range
-
-    def _get_tag_ranges(self, content: dict):
-        """Get tag_ranges and check validity:
-        - It should be ordered
-        - Not unnecessary partition (eg. [[10,20],[20,30]])
-        - Singular intergers are changed to ranges (eg. [10] to [[10, 10]])
-        The ranges are understood as [inclusive, inclusive]"""
-        ranges = content["tag_ranges"]
-        if len(ranges) < 1:
-            detail = "tag_ranges is empty"
-            raise HTTPException(400, detail=detail)
-        last_tag = 0
-        ranges_n = len(ranges)
-        for i in range(0, ranges_n):
-            ranges[i] = self.map_singular_values(ranges[i])
-            if ranges[i][0] > ranges[i][1]:
-                detail = f"The range {ranges[i]} is not ordered"
-                raise HTTPException(400, detail=detail)
-            if last_tag and last_tag > ranges[i][0]:
-                detail = f"tag_ranges is not ordered. {last_tag}"\
-                         f" is higher than {ranges[i][0]}"
-                raise HTTPException(400, detail=detail)
-            if last_tag and last_tag == ranges[i][0] - 1:
-                detail = f"tag_ranges has an unnecessary partition. "\
-                         f"{last_tag} is before to {ranges[i][0]}"
-                raise HTTPException(400, detail=detail)
-            if last_tag and last_tag == ranges[i][0]:
-                detail = f"tag_ranges has repetition. {ranges[i-1]}"\
-                         f" have same values as {ranges[i]}"
-                raise HTTPException(400, detail=detail)
-            last_tag = ranges[i][1]
-        if ranges[-1][1] > 4095:
-            detail = "Maximum value for tag_ranges is 4095"
-            raise HTTPException(400, detail=detail)
-        if ranges[0][0] < 1:
-            detail = "Minimum value for tag_ranges is 1"
-            raise HTTPException(400, detail=detail)
-        return ranges
-
     @rest('v3/interfaces/{interface_id}/tag_ranges', methods=['POST'])
     @validate_openapi(spec)
     def set_tag_range(self, request: Request) -> JSONResponse:
@@ -541,7 +494,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         content_type_json_or_415(request)
         content = get_json_or_400(request, self.controller.loop)
         tag_type = content.get("tag_type")
-        ranges = self._get_tag_ranges(content)
+        try:
+            ranges = get_tag_ranges(content["tag_ranges"])
+        except KytosInvalidRanges as err:
+            raise HTTPException(400, detail=err)
         interface_id = request.path_params["interface_id"]
         interface = self.controller.get_interface_by_id(interface_id)
         if not interface:

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
 -e .

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range#egg=kytos[dev]
 -e .

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,7 +13,6 @@ from kytos.core.exceptions import (KytosSetTagRangeError,
                                    KytosTagtypeNotSupported)
 from kytos.core.interface import Interface
 from kytos.core.link import Link
-from kytos.core.rest_api import HTTPException
 from kytos.core.switch import Switch
 from kytos.lib.helpers import (get_interface_mock, get_link_mock,
                                get_controller_mock, get_switch_mock,
@@ -1629,57 +1628,6 @@ class TestMain:
         )
         assert mock_notify_link_status_change.call_count == 2
         mock_notify_topology_update.assert_called_once()
-
-    def test_map_singular_values(self):
-        """Test map_singular_values"""
-        mock_tag = 201
-        result = self.napp.map_singular_values(mock_tag)
-        assert result == [201, 201]
-
-        mock_tag = [201]
-        result = self.napp.map_singular_values(mock_tag)
-        assert result == [201, 201]
-
-    def test_get_tag_ranges(self):
-        """Test _get_tag_ranges"""
-        mock_content = {'tag_ranges': [100, [150], [200, 3000]]}
-        result = self.napp._get_tag_ranges(mock_content)
-        assert result == [[100, 100], [150, 150], [200, 3000]]
-
-        # Empty
-        mock_content = {'tag_ranges': []}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
-
-        # Range not ordered
-        mock_content = {'tag_ranges': [[20, 19]]}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
-
-        # Ranges not ordered
-        mock_content = {'tag_ranges': [[20, 50], [30, 3000]]}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
-
-        # Unnecessary partition
-        mock_content = {'tag_ranges': [[20, 50], [51, 3000]]}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
-
-        # Repeated tag
-        mock_content = {'tag_ranges': [[20, 50], [50, 3000]]}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
-
-        # Over 4095
-        mock_content = {'tag_ranges': [[20, 50], [50, 4096]]}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
-
-        # Under 1
-        mock_content = {'tag_ranges': [[0, 50], [50, 3000]]}
-        with pytest.raises(HTTPException):
-            self.napp._get_tag_ranges(mock_content)
 
     async def test_set_tag_range(self, event_loop):
         """Test set_tag_range"""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1675,7 +1675,7 @@ class TestMain:
         mock_switch = get_switch_mock(dpid)
         mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
         mock_interface.set_tag_ranges = MagicMock()
-        mock_interface.set_tag_ranges.side_effect = KytosSetTagRangeError()
+        mock_interface.set_tag_ranges.side_effect = KytosSetTagRangeError("")
         mock_interface.notify_interface_tags = MagicMock()
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = mock_interface
@@ -1696,7 +1696,9 @@ class TestMain:
         mock_switch = get_switch_mock(dpid)
         mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
         mock_interface.set_tag_ranges = MagicMock()
-        mock_interface.set_tag_ranges.side_effect = KytosTagtypeNotSupported()
+        mock_interface.set_tag_ranges.side_effect = KytosTagtypeNotSupported(
+            ""
+        )
         self.napp.handle_on_interface_tags = MagicMock()
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = mock_interface
@@ -1749,7 +1751,7 @@ class TestMain:
         mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
         mock_interface.remove_tag_ranges = MagicMock()
         remove_tag = mock_interface.remove_tag_ranges
-        remove_tag.side_effect = KytosTagtypeNotSupported()
+        remove_tag.side_effect = KytosTagtypeNotSupported("")
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = mock_interface
         url = f"{self.base_endpoint}/interfaces/{interface_id}/tag_ranges"


### PR DESCRIPTION
Closes #174 

### Summary

Moved `_get_tag_ranges()` to `kytos/core/tag_ranges.py`
Now using `KytosInvalidRanges` exception
This PR relies in kytos PR [#428](https://github.com/kytos-ng/kytos/pull/428)

### Local tests

Unit tests are moved to `kytos/core`

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 47%]
tests/test_e2e_15_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 72%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 75%]
tests/test_e2e_40_sdntrace.py .............                              [ 80%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_42_sdntrace.py ..                                         [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```
