### PR TITLE
chore: refactored `unittest.TestCase` as pytest unit tests

### DIFF
--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,10 +1,9 @@
 """Module to test model class."""
-from unittest import TestCase
 
 from napps.kytos.topology.models import Host
 
 
-class TestHost(TestCase):
+class TestHost:
     """Test the model class."""
 
     mac = "6e:c2:ea:c4:18:12"
@@ -13,9 +12,9 @@ class TestHost(TestCase):
         """Test as_dict."""
         host = Host(self.mac)
         expected = {'mac': self.mac, 'type': 'host'}
-        self.assertEqual(host.as_dict(), expected)
+        assert host.as_dict() == expected
 
     def test_id(self):
         """Test id."""
         host = Host(self.mac)
-        self.assertEqual(host.id, self.mac)
+        assert host.id == self.mac

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -1,16 +1,15 @@
 """Module to TopoController."""
 
-from unittest import TestCase
 from unittest.mock import MagicMock
 
 from napps.kytos.topology.controllers import TopoController
 from napps.kytos.topology.db.models import LinkDoc, SwitchDoc
 
 
-class TestTopoController(TestCase):  # pylint: disable=too-many-public-methods
+class TestTopoController:  # pylint: disable=too-many-public-methods
     """Test the Main class."""
 
-    def setUp(self) -> None:
+    def setup_method(self) -> None:
         """Execute steps before each tests."""
         self.topo = TopoController(MagicMock())
         self.dpid = "00:00:00:00:00:00:00:01"

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -5,8 +5,10 @@ from unittest.mock import MagicMock
 from napps.kytos.topology.controllers import TopoController
 from napps.kytos.topology.db.models import LinkDoc, SwitchDoc
 
+# pylint: disable=too-many-public-methods,attribute-defined-outside-init
 
-class TestTopoController:  # pylint: disable=too-many-public-methods
+
+class TestTopoController:
     """Test the Main class."""
 
     def setup_method(self) -> None:


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/376

### Summary

- Refactored `unittest.TestCase` as pytest unit tests
- No need to update the changelog either for this case

### Local Tests

Not needed

### End-to-End Tests

Not needed