### PR TITLE
Added `special_available_tags` to `interface_details`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Added
 - Added ``Tag_ranges`` documentation to openapi.yml
 - Added API request POST and DELETE to modify ``Interface.tag_ranges``
 - Added listener for ``kytos/core.interface_tags`` event to save any changes made to ``Interface`` attributes ``tag_ranges`` and ``available_tags``
+- Added script ``special_vlan_allocation.py`` to add ``special_available_tags`` and ``special_tags`` fields to ``interface_details`` collection.
+- Added endpoint ``POST v3/interfaces/{interface_id}/special_tags`` to set ``special_tags`` to interfaces.
 
 Deprecated
 ==========

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -278,7 +278,7 @@ class TopoController:
         available_tags: dict[str, list[list[int]]],
         tag_ranges: dict[str, list[list[int]]],
         special_available_tags: dict[str, list[str]],
-        special_tag_range: dict[str, list[str]]
+        special_tags: dict[str, list[str]]
     ) -> Optional[dict]:
         """Update or insert interfaces details."""
         utc_now = datetime.utcnow()
@@ -287,7 +287,7 @@ class TopoController:
                 "available_tags": available_tags,
                 "tag_ranges": tag_ranges,
                 "special_available_tags": special_available_tags,
-                "special_tag_range": special_tag_range,
+                "special_tags": special_tags,
                 "updated_at": utc_now
         }).dict(exclude={"inserted_at"})
         updated = self.db.interface_details.find_one_and_update(

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -13,7 +13,6 @@ from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
 from kytos.core import log
 from kytos.core.db import Mongo
-from kytos.core.interface import Interface
 from kytos.core.retry import before_sleep, for_all_methods, retries
 from napps.kytos.topology.db.models import (InterfaceDetailDoc, LinkDoc,
                                             SwitchDoc)
@@ -276,7 +275,8 @@ class TopoController:
         self,
         id_: str,
         available_tags: dict[str, list[list[int]]],
-        tag_ranges: dict[str, list[list[int]]]
+        tag_ranges: dict[str, list[list[int]]],
+        special_available_tags: dict[str, list[str]]
     ) -> Optional[dict]:
         """Update or insert interfaces details."""
         utc_now = datetime.utcnow()
@@ -284,6 +284,7 @@ class TopoController:
                 "_id": id_,
                 "available_tags": available_tags,
                 "tag_ranges": tag_ranges,
+                "special_available_tags": special_available_tags,
                 "updated_at": utc_now
         }).dict(exclude={"inserted_at"})
         updated = self.db.interface_details.find_one_and_update(

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -271,12 +271,14 @@ class TopoController:
         return self.db.links.update_many({"_id": {"$in": link_ids}},
                                          update_expr)
 
+    # pylint: disable=too-many-arguments
     def upsert_interface_details(
         self,
         id_: str,
         available_tags: dict[str, list[list[int]]],
         tag_ranges: dict[str, list[list[int]]],
-        special_available_tags: dict[str, list[str]]
+        special_available_tags: dict[str, list[str]],
+        special_tag_range: dict[str, list[str]]
     ) -> Optional[dict]:
         """Update or insert interfaces details."""
         utc_now = datetime.utcnow()
@@ -285,6 +287,7 @@ class TopoController:
                 "available_tags": available_tags,
                 "tag_ranges": tag_ranges,
                 "special_available_tags": special_available_tags,
+                "special_tag_range": special_tag_range,
                 "updated_at": utc_now
         }).dict(exclude={"inserted_at"})
         updated = self.db.interface_details.find_one_and_update(

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -127,3 +127,4 @@ class InterfaceDetailDoc(DocumentBaseModel):
     available_tags: Dict[str, List[List[int]]]
     tag_ranges: Dict[str, List[List[int]]]
     special_available_tags: Dict[str, List[str]]
+    special_tag_range: Dict[str, List[str]]

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -127,4 +127,4 @@ class InterfaceDetailDoc(DocumentBaseModel):
     available_tags: Dict[str, List[List[int]]]
     tag_ranges: Dict[str, List[List[int]]]
     special_available_tags: Dict[str, List[str]]
-    special_tag_range: Dict[str, List[str]]
+    special_tags: Dict[str, List[str]]

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -126,3 +126,4 @@ class InterfaceDetailDoc(DocumentBaseModel):
 
     available_tags: Dict[str, List[List[int]]]
     tag_ranges: Dict[str, List[List[int]]]
+    special_available_tags: Dict[str, List[str]]

--- a/main.py
+++ b/main.py
@@ -719,7 +719,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Update interface details"""
         intf_id = interface.id
         self.topo_controller.upsert_interface_details(
-            intf_id, interface.available_tags, interface.tag_ranges
+            intf_id, interface.available_tags, interface.tag_ranges,
+            interface.special_available_tags
         )
 
     @listen_to('.*.switch.(new|reconnected)')
@@ -1137,7 +1138,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             interface = switch.interfaces[port_number]
             interface.set_available_tags_tag_ranges(
                 available_tags,
-                interface_details['tag_ranges']
+                interface_details['tag_ranges'],
+                interface_details['special_available_tags']
             )
 
     @listen_to('topology.interruption.start')

--- a/main.py
+++ b/main.py
@@ -525,18 +525,18 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(400, detail=str(err))
         return JSONResponse("Operation Successful", status_code=200)
 
-    @rest('v3/interfaces/{interface_id}/special_tag_range', methods=['POST'])
+    @rest('v3/interfaces/{interface_id}/special_tags', methods=['POST'])
     @validate_openapi(spec)
-    def set_special_tag_range(self, request: Request) -> JSONResponse:
-        """Set special_tag_range"""
+    def set_special_tags(self, request: Request) -> JSONResponse:
+        """Set special_tags"""
         content_type_json_or_415(request)
         content = get_json_or_400(request, self.controller.loop)
         tag_type = content.get("tag_type")
-        special_tag_range = content["special_tag_range"]
+        special_tags = content["special_tags"]
         interface_id = request.path_params["interface_id"]
         interface = self.controller.get_interface_by_id(interface_id)
         try:
-            interface.set_special_tag_ranges(special_tag_range, tag_type)
+            interface.set_special_tagss(tag_type, special_tags)
             self.handle_on_interface_tags(interface)
         except KytosTagError as err:
             raise HTTPException(400, detail=str(err))
@@ -545,7 +545,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @rest('v3/interfaces/tag_ranges', methods=['GET'])
     @validate_openapi(spec)
     def get_all_tag_ranges(self, _: Request) -> JSONResponse:
-        """Get all tag_ranges, available_tags, special_tag_range
+        """Get all tag_ranges, available_tags, special_tags
          and special_available_tags from interfaces"""
         result = {}
         for switch in self.controller.switches.copy().values():
@@ -553,7 +553,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 result[interface.id] = {
                     "available_tags": interface.available_tags,
                     "tag_ranges": interface.tag_ranges,
-                    "special_tag_range": interface.special_tag_range,
+                    "special_tags": interface.special_tags,
                     "special_available_tags": interface.special_available_tags
                 }
         return JSONResponse(result, status_code=200)
@@ -561,7 +561,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     @rest('v3/interfaces/{interface_id}/tag_ranges', methods=['GET'])
     @validate_openapi(spec)
     def get_tag_ranges_by_intf(self, request: Request) -> JSONResponse:
-        """Get tag_ranges, available_tags, special_tag_range
+        """Get tag_ranges, available_tags, special_tags
          and special_available_tags from an interface"""
         interface_id = request.path_params["interface_id"]
         interface = self.controller.get_interface_by_id(interface_id)
@@ -571,7 +571,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             interface_id: {
                 "available_tags": interface.available_tags,
                 "tag_ranges": interface.tag_ranges,
-                "special_tag_range": interface.special_tag_range,
+                "special_tags": interface.special_tags,
                 "special_available_tags": interface.special_available_tags
             }
         }
@@ -744,7 +744,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller.upsert_interface_details(
             intf_id, interface.available_tags, interface.tag_ranges,
             interface.special_available_tags,
-            interface.special_tag_range
+            interface.special_tags
         )
 
     @listen_to('.*.switch.(new|reconnected)')
@@ -1164,7 +1164,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 available_tags,
                 interface_details['tag_ranges'],
                 interface_details['special_available_tags'],
-                interface_details['special_tag_range'],
+                interface_details['special_tags'],
             )
 
     @listen_to('topology.interruption.start')

--- a/main.py
+++ b/main.py
@@ -535,8 +535,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         special_tags = content["special_tags"]
         interface_id = request.path_params["interface_id"]
         interface = self.controller.get_interface_by_id(interface_id)
+        if not interface:
+            raise HTTPException(404, detail="Interface not found")
         try:
-            interface.set_special_tagss(tag_type, special_tags)
+            interface.set_special_tags(tag_type, special_tags)
             self.handle_on_interface_tags(interface)
         except KytosTagError as err:
             raise HTTPException(400, detail=str(err))

--- a/openapi.yml
+++ b/openapi.yml
@@ -487,7 +487,7 @@ paths:
         '400':
           description: Bad request.
         '404':
-          description: Switch or Interface not found.
+          description: Interface not found.
     delete:
       summary: Set tag ranges from an Interface for a given tag_type to default value [1, 4095]
       parameters:
@@ -510,7 +510,7 @@ paths:
         '400':
           description: Bad request.
         '404':
-          description: Switch or Interface not found.
+          description: Interface not found.
   /v3/interfaces/{interface_id}/special_tags:
     post:
       summary: Set special_tags from an interface
@@ -544,7 +544,7 @@ paths:
         '400':
           description: Bad request.
         '404':
-          description: Switch or Interface not found.
+          description: Interface not found.
   /v3/links:
     get:
       summary: Return a json with all the links in the topology.

--- a/openapi.yml
+++ b/openapi.yml
@@ -431,7 +431,7 @@ paths:
                 "00:00:00:00:00:00:00:01:2":
                   "available_tags": [[1, 4096]]
                   "tag_ranges": [[1,4096]]
-                  "special_tag_range": ["untagged", "any"]
+                  "special_tags": ["untagged", "any"]
                   "special_available_tags": ["any"]
   /v3/interfaces/{interface_id}/tag_ranges:
     get:
@@ -462,7 +462,7 @@ paths:
                 "00:00:00:00:00:00:00:01:2":
                   "available_tags": [[1, 4096]]
                   "tag_ranges": [[1,4096]]
-                  "special_tag_range": ["untagged", "any"]
+                  "special_tags": ["untagged", "any"]
                   "special_available_tags": ["any"]
         '404':
           description: Interface not found
@@ -511,9 +511,9 @@ paths:
           description: Bad request.
         '404':
           description: Switch or Interface not found.
-  /v3/interfaces/{interface_id}/special_tag_range:
+  /v3/interfaces/{interface_id}/special_tags:
     post:
-      summary: Set special_tag_range from an interface
+      summary: Set special_tags from an interface
       parameters:
         - name: interface_id
           schema:
@@ -529,12 +529,12 @@ paths:
               type: object
               required:
                 - tag_type
-                - special_tag_range
+                - special_tags
               properties:
                 tag_type:
                   type: string
                   enum: ['vlan']
-                special_tag_range:
+                special_tags:
                   type: array
                   items:
                     type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -7,7 +7,7 @@ servers:
   - url: /api/kytos/topology
     description: Local server (uses test data)
 paths:
-  /api/kytos/topology/v3/:
+  /v3/:
     get:
       summary: Return the latest known topology.
       description: This topology is updated when there are network events.
@@ -27,7 +27,7 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Switch"
-  /api/kytos/topology/v3/switches:
+  /v3/switches:
     get:
       summary: Return a json with all the switches in the topology.
       description: Return all the switches in the topology.
@@ -43,7 +43,7 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Switch"
-  /api/kytos/topology/v3/switches/{dpid}/enable:
+  /v3/switches/{dpid}/enable:
     post:
       summary: Administratively enable a switch in the topology.
       description: Administratively enable a switch in the topology. The dpid
@@ -71,7 +71,7 @@ paths:
               schema:
                 type: string
                 example: Switch not found
-  /api/kytos/topology/v3/switches/{dpid}/disable:
+  /v3/switches/{dpid}/disable:
     post:
       summary: Administratively disable a switch in the topology.
       description: Administratively disable a switch in the topology. The dpid
@@ -99,7 +99,7 @@ paths:
               schema:
                 type: string
                 example: Switch not found
-  /api/kytos/topology/v3/switches/{dpid}/metadata:
+  /v3/switches/{dpid}/metadata:
     get:
       summary: Get metadata from a switch.
       description: Return a metadata from a switch. The dpid is required.
@@ -156,7 +156,7 @@ paths:
               schema:
                 type: string
                 example: Switch not found
-  /api/kytos/topology/v3/switches/{dpid}/metadata/{key}:
+  /v3/switches/{dpid}/metadata/{key}:
     delete:
       summary: Delete metadata from a switch.
       description: Delete a metadata from a switch. The dpid and metadata key
@@ -191,7 +191,7 @@ paths:
                 type: string
                 example: Switch not found
 
-  /api/kytos/topology/v3/interfaces:
+  /v3/interfaces:
     get:
       summary: Return a json with all the interfaces in the topology.
       description: Return all interfaces in the topology.
@@ -208,7 +208,7 @@ paths:
                     additionalProperties:
                       $ref: '#/components/schemas/Interface'
 
-  /api/kytos/topology/v3/interfaces/{interface_id}/enable:
+  /v3/interfaces/{interface_id}/enable:
     post:
       summary: Administratively enable an interface in the topology.
       description: Administratively enable an interface in the topology. The
@@ -236,7 +236,7 @@ paths:
                 type: string
                 example: Switch not found
 
-  /api/kytos/topology/v3/interfaces/switch/{dpid}/enable:
+  /v3/interfaces/switch/{dpid}/enable:
     post:
       summary: Administratively enable all interfaces on a switch.
       description: Administratively enable all interfaces on a switch.
@@ -264,7 +264,7 @@ paths:
                 type: string
                 example: Switch not found
 
-  /api/kytos/topology/v3/interfaces/{interface_id}/disable:
+  /v3/interfaces/{interface_id}/disable:
     post:
       summary: Administratively disable an interface in the topology.
       description: Administratively disable an interface in the topology.
@@ -292,7 +292,7 @@ paths:
                 type: string
                 example: Switch not found
 
-  /api/kytos/topology/v3/interfaces/switch/{dpid}/disable:
+  /v3/interfaces/switch/{dpid}/disable:
     post:
       summary: Administratively disable all interfaces on a switch.
       description: Administratively disable all interfaces on a switch.
@@ -320,7 +320,7 @@ paths:
                 type: string
                 example: Switch not found
 
-  /api/kytos/topology/v3/interfaces/{interface_id}/metadata:
+  /v3/interfaces/{interface_id}/metadata:
     get:
       summary: Get metadata from an interface.
       description: Return metadata from an interface. The interface_id is
@@ -376,7 +376,7 @@ paths:
               schema:
                 type: string
                 example: Switch not found
-  /api/kytos/topology/v3/interfaces/{interface_id}/metadata/{key}:
+  /v3/interfaces/{interface_id}/metadata/{key}:
     delete:
       summary: Delete metadata from an interface.
       description: Delete metadata from an interface. The interface_id and
@@ -431,6 +431,8 @@ paths:
                 "00:00:00:00:00:00:00:01:2":
                   "available_tags": [[1, 4096]]
                   "tag_ranges": [[1,4096]]
+                  "special_tag_range": ["untagged", "any"]
+                  "special_available_tags": ["any"]
   /v3/interfaces/{interface_id}/tag_ranges:
     get:
       summary: Get tag_ranges and available_tags from an interface
@@ -460,10 +462,12 @@ paths:
                 "00:00:00:00:00:00:00:01:2":
                   "available_tags": [[1, 4096]]
                   "tag_ranges": [[1,4096]]
+                  "special_tag_range": ["untagged", "any"]
+                  "special_available_tags": ["any"]
         '404':
           description: Interface not found
     post:
-      summary: Set tag_range from an interface
+      summary: Set tag_ranges from an interface
       parameters:
         - name: interface_id
           schema:
@@ -507,7 +511,41 @@ paths:
           description: Bad request.
         '404':
           description: Switch or Interface not found.
-  /api/kytos/topology/v3/links:
+  /v3/interfaces/{interface_id}/special_tag_range:
+    post:
+      summary: Set special_tag_range from an interface
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: The interface ID
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - tag_type
+                - special_tag_range
+              properties:
+                tag_type:
+                  type: string
+                  enum: ['vlan']
+                special_tag_range:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad request.
+        '404':
+          description: Switch or Interface not found.
+  /v3/links:
     get:
       summary: Return a json with all the links in the topology.
       description: Links are connections between interfaces.
@@ -523,7 +561,7 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Link"
-  /api/kytos/topology/v3/links/{link_id}/enable:
+  /v3/links/{link_id}/enable:
     post:
       summary: Administratively enable a link in the topology.
       description: Administratively enable a link in the topology. The link_id
@@ -550,7 +588,7 @@ paths:
               schema:
                 type: string
                 example: Link not found
-  /api/kytos/topology/v3/links/{link_id}/disable:
+  /v3/links/{link_id}/disable:
     post:
       summary: Administratively disable a link in the topology.
       description: Administratively disable a link in the topology.
@@ -577,7 +615,7 @@ paths:
               schema:
                 type: string
                 example: Link not found
-  /api/kytos/topology/v3/links/{link_id}/metadata:
+  /v3/links/{link_id}/metadata:
     get:
       summary: Get metadata from a link.
       description: Get metadata from a link. The link_id is required.
@@ -632,7 +670,7 @@ paths:
               schema:
                 type: string
                 example: Link not found
-  /api/kytos/topology/v3/links/{link_id}/metadata/{key}:
+  /v3/links/{link_id}/metadata/{key}:
     delete:
       summary: Delete metadata from a link.
       description: Delete metadata from a link. The link_id and metadata key

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range_special#egg=kytos[dev]
 -e .

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range_special#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
 -e .

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -163,7 +163,7 @@ Modified 0 switches objects
     tag_ranges = {"vlan": [[1, 4095]]}
 ```
 
-This scripts takes into account UNIs TAG values as well.
+This scripts takes into account UNIs TAG (only integers) values as well.
 
 #### Pre-requisites
 
@@ -228,6 +228,73 @@ An `ERROR` can be shown if a duplicated `TAG` is detected in different `EVC`s. A
 
 ```
 Error: Detected duplicated 200 TAG in EVCs 861a11d8fce148 and d74e18464d524b in interface 00:00:00:00:00:00:00:01:1
+```
+
+</details>
+
+<details><summary><h3>Add <code>special_available_tags</code> field to each Interface document in <code>interface_details</code> collection </h3></summary>
+
+[`special_vlan_allocation.py`](./special_vlan_allocation.py) is to add the new field ``special_available_tags`` to each interface document. This new field will keep track of special vlan usage:
+
+```
+special_available_tags = {"vlan": ["untagged", "any"]}
+```
+
+This scripts takes into account UNIs TAG values (only string) as well.
+
+#### Pre-requisites
+
+- There's no additional Python libraries dependencies required, other than installing the existing `topology`'s, or if you're running in development locally then installing `requirements/dev.in`
+- Make sure you don't have `kytosd` running with otherwise topology will start writing to MongoDB, and the application could overwrite the data you're trying to insert with this script.
+- Make sure MongoDB replica set is up and running.
+- Export the following MongnoDB variables accordingly in case your running outside of a container
+
+```
+export MONGO_USERNAME=
+export MONGO_PASSWORD=
+export MONGO_DBNAME=napps
+export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
+```
+
+#### How to use
+
+- The following `CMD` commands are available:
+
+```
+aggregate_outdated_interfaces
+update_database
+```
+
+`aggregate_outdated_interfaces` option is to see how many documents are going to be modified and how many are going to be added.
+
+```
+CMD=aggregate_outdated_interfaces python3 scripts/special_vlan_allocation.py
+```
+
+For the interfaces that are going to be modified, they are going to be listed:
+
+```
+There are 1 outdated interface documents which do not have 'special_available_tags' field:
+00:00:00:00:00:00:00:02:3
+```
+
+`update_database` updates and adds the required documents for compatability
+
+```
+CMD=update_database python3 scripts/special_vlan_allocation.py
+```
+
+The final messages will show how many interfaces have been modified:
+
+```
+1 interface was/were updated:
+00:00:00:00:00:00:00:02:3
+```
+
+An `ERROR` can be shown if a duplicated `TAG` is detected in different `EVC`s. After this the pocess will exit without making any modification or adittion.
+
+```
+Error: Detected duplicated vlan 'any' TAG in EVCs d68eb033688a48 and 861a11d8fce148 in interface 00:00:00:00:00:00:00:01:1
 ```
 
 </details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -232,12 +232,13 @@ Error: Detected duplicated 200 TAG in EVCs 861a11d8fce148 and d74e18464d524b in 
 
 </details>
 
-<details><summary><h3>Add <code>special_available_tags</code> field to each Interface document in <code>interface_details</code> collection </h3></summary>
+<details><summary><h3>Add <code>special_available_tags</code> and <code>special_tags</code> field to each Interface document in <code>interface_details</code> collection </h3></summary>
 
-[`special_vlan_allocation.py`](./special_vlan_allocation.py) is to add the new field ``special_available_tags`` to each interface document. This new field will keep track of special vlan usage:
+[`special_vlan_allocation.py`](./special_vlan_allocation.py) is to add the new field ``special_available_tags`` and ``special_tags`` to each interface document. This new field will keep track of special vlan usage:
 
 ```
-special_available_tags = {"vlan": ["untagged", "any"]}
+special_available_tags = {"vlan": ["untagged"]}
+special_tags = {"vlan": ["untagged", "any"]}
 ```
 
 This scripts takes into account UNIs TAG values (only string) as well.
@@ -274,7 +275,7 @@ CMD=aggregate_outdated_interfaces python3 scripts/special_vlan_allocation.py
 For the interfaces that are going to be modified, they are going to be listed:
 
 ```
-There are 1 outdated interface documents which do not have 'special_available_tags' field:
+There are 13 outdated interface documents which do not have 'special_available_tags' and/or 'special_tags' field:
 00:00:00:00:00:00:00:02:3
 ```
 

--- a/scripts/special_vlan_allocation.py
+++ b/scripts/special_vlan_allocation.py
@@ -1,0 +1,106 @@
+import datetime
+import sys
+import os
+from collections import defaultdict
+from kytos.core.db import Mongo
+
+
+def aggregate_outdated_interfaces(mongo: Mongo):
+    """Aggregate outdated interfaces details"""
+    db = mongo.client[mongo.db_name]
+    outdated_intfs = set()
+    result = db.interface_details.aggregate(
+        [
+            {"$project": {
+                "_id": 0,
+                "id": 1,
+                "special_available_tags": 1,
+            }}
+        ]
+    )
+    for document in result:
+        if not "special_available_tags" in document:
+            outdated_intfs.add(document["id"])
+    
+    if outdated_intfs:
+        print(f"There are {len(outdated_intfs)} outdated interface documents"
+              " which do not have 'special_available_tags' field:")
+        for intf_id in outdated_intfs:
+            print(intf_id)
+    else:
+        print("All interfaces are updated.")
+
+def update_database(mongo: Mongo):
+    db = mongo.client[mongo.db_name]
+    intfs_documents = db.interface_details.find()
+    evc_documents = db.evcs.find({"archived": False})
+
+    tag_by_intf = defaultdict(set)
+    evc_intf = defaultdict(str)
+
+    for evc in evc_documents:
+        tag_a = evc["uni_a"].get("tag")
+        if tag_a and isinstance(tag_a["value"], str):
+            intf_id = evc["uni_a"]["interface_id"]
+            if tag_a["value"] in tag_by_intf[intf_id]:
+                print(f"Error: Detected duplicated vlan '{tag_a['value']}' TAG"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id+tag_a['value']]}"
+                      f" in interface {intf_id}")
+                sys.exit(1)
+            tag_by_intf[intf_id].add(tag_a["value"])
+            evc_intf[intf_id+tag_a["value"]] = evc["id"]
+        tag_z = evc["uni_z"].get("tag")
+
+        if tag_z and isinstance(tag_z["value"], str):
+            intf_id = evc["uni_z"]["interface_id"]
+            if tag_z["value"] in tag_by_intf[intf_id]:
+                print(f"Error: Detected duplicated vlan '{tag_z['value']}' TAG"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id+tag_z['value']]}"
+                      f" in interface {intf_id}")
+                sys.exit(1)
+            tag_by_intf[intf_id].add(tag_z["value"])
+            evc_intf[intf_id+tag_z["value"]] = evc["id"]
+
+    default_special_vlans = {"untagged", "any"}
+    intf_count = 0
+    message_intfs = ""
+    for intf in intfs_documents:
+        _id = intf["id"]
+        current_field = intf.get("special_available_tags", None)
+        if current_field:
+            current_field = set(current_field["vlan"])
+        expected_field = default_special_vlans - tag_by_intf.get(_id, set())
+        if current_field == expected_field:
+            continue
+        db.interface_details.update_one(
+            {"id": _id},
+            {
+                "$set":
+                {
+                    "special_available_tags": {"vlan": list(expected_field)}
+                }
+            }
+        )
+        message_intfs += f"{_id}\n"
+        intf_count += 1
+    if intf_count:
+        print(f"{intf_count} interface was/were updated:")
+        print(message_intfs)
+    else:
+        print("All interfaces are updated already.")
+
+
+if __name__ == "__main__":
+    mongo = Mongo()
+    cmds = {
+        "aggregate_outdated_interfaces": aggregate_outdated_interfaces,
+        "update_database": update_database,
+    }
+    try:
+        cmd = os.environ["CMD"]
+        cmds[cmd](mongo)
+    except KeyError:
+        print(
+            f"Please set the 'CMD' env var. \nIt has to be one of these: {list(cmds.keys())}"
+        )
+        sys.exit(1)

--- a/scripts/vlan_pool.py
+++ b/scripts/vlan_pool.py
@@ -58,31 +58,31 @@ def update_database(mongo: Mongo):
     intf_documents = db.interface_details.find()
     evc_documents = db.evcs.find({"archived": False})
 
-    evc_intf = defaultdict(set)
+    evc_intf = defaultdict(str)
     evc_tags = defaultdict(set)
 
     for evc in evc_documents:
         tag_a = evc["uni_a"].get("tag")
         if tag_a:
             intf_id = evc["uni_a"]["interface_id"]
-            if tag_a["value"] in evc_tags[intf_id]:
+            if tag_a["value"] in evc_tags[intf_id] and isinstance(tag_a["value"], int):
                 print(f"Error: Detected duplicated {tag_a['value']} TAG"
-                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id+str(tag_a['value'])]}"
                       f" in interface {intf_id}")
                 sys.exit(1)
             evc_tags[intf_id].add(tag_a["value"])
-            evc_intf[intf_id].add(evc["id"])
+            evc_intf[intf_id+str(tag_a["value"])] = evc["id"]
 
         tag_z = evc["uni_z"].get("tag")
         if tag_z:
             intf_id = evc["uni_z"]["interface_id"]
-            if tag_z["value"] in evc_tags[intf_id]:
+            if tag_z["value"] in evc_tags[intf_id] and isinstance(tag_z["value"], int):
                 print(f"Error: Detected duplicated {tag_z['value']} TAG"
-                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id+str(tag_z['value'])]}"
                       f" in interface {intf_id}")
                 sys.exit(1)
             evc_tags[intf_id].add(tag_z["value"])
-            evc_intf[intf_id].add(evc["id"])
+            evc_intf[intf_id+str(tag_z["value"])] = evc["id"]
 
     intf_count = 0
     for document in intf_documents:
@@ -151,31 +151,31 @@ def aggregate_outdated_interfaces(mongo: Mongo):
         print(messages)
     
     evc_documents = db.evcs.find({"archived": False})
-    evc_intf = defaultdict(set)
+    evc_intf = defaultdict(str)
     evc_tags = defaultdict(set)
 
     for evc in evc_documents:
         tag_a = evc["uni_a"].get("tag")
         if tag_a:
             intf_id = evc["uni_a"]["interface_id"]
-            if tag_a["value"] in evc_tags[intf_id]:
+            if tag_a["value"] in evc_tags[intf_id] and isinstance(tag_a["value"], int):
                 print(f"WARNING: Detected duplicated {tag_a['value']} TAG"
-                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id+str(tag_a['value'])]}"
                       f" in interface {intf_id}")
                 print()
             evc_tags[intf_id].add(tag_a["value"])
-            evc_intf[intf_id].add(evc["id"])
+            evc_intf[intf_id+str(tag_a["value"])] = evc["id"]
 
         tag_z = evc["uni_z"].get("tag")
         if tag_z:
             intf_id = evc["uni_z"]["interface_id"]
-            if tag_z["value"] in evc_tags[intf_id]:
+            if tag_z["value"] in evc_tags[intf_id] and isinstance(tag_z["value"], int):
                 print(f"WARNING: Detected duplicated {tag_z['value']} TAG"
-                      f" in EVCs {evc['id']} and {evc_intf[intf_id].pop()}"
+                      f" in EVCs {evc['id']} and {evc_intf[intf_id+str(tag_z['value'])]}"
                       f" in interface {intf_id}")
                 print()
             evc_tags[intf_id].add(tag_z["value"])
-            evc_intf[intf_id].add(evc["id"])
+            evc_intf[intf_id+str(tag_z["value"])] = evc["id"]
 
     for id_ in document_ids:
         evc_tags.pop(id_, None)

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -66,7 +66,8 @@ def test_interface_detail_doc() -> None:
     payload = {
         "available_tags": {"vlan": [[200, 300], [500, 550]]},
         "tag_ranges": {"vlan": [[100, 4095]]},
-        "special_available_tags": {"vlan": ["any"]}
+        "special_available_tags": {"vlan": ["any"]},
+        "special_tag_range": {"vlan": ["any", "untagged"]}
     }
     model = InterfaceDetailDoc(**payload)
     assert model

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -67,7 +67,7 @@ def test_interface_detail_doc() -> None:
         "available_tags": {"vlan": [[200, 300], [500, 550]]},
         "tag_ranges": {"vlan": [[100, 4095]]},
         "special_available_tags": {"vlan": ["any"]},
-        "special_tag_range": {"vlan": ["any", "untagged"]}
+        "special_tags": {"vlan": ["any", "untagged"]}
     }
     model = InterfaceDetailDoc(**payload)
     assert model

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -4,7 +4,8 @@ the remaning parts."""
 
 from datetime import datetime
 
-from napps.kytos.topology.db.models import DocumentBaseModel, SwitchDoc
+from napps.kytos.topology.db.models import (DocumentBaseModel,
+                                            InterfaceDetailDoc, SwitchDoc)
 
 
 def test_document_base_model_dict() -> None:
@@ -58,3 +59,14 @@ def test_switch_doc_no_preset_interfaces() -> None:
     model = SwitchDoc(**payload)
     assert model
     assert model.interfaces == interfaces
+
+
+def test_interface_detail_doc() -> None:
+    """Test InterfaceDetailDoc"""
+    payload = {
+        "available_tags": {"vlan": [[200, 300], [500, 550]]},
+        "tag_ranges": {"vlan": [[100, 4095]]},
+        "special_available_tags": {"vlan": ["any"]}
+    }
+    model = InterfaceDetailDoc(**payload)
+    assert model

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -429,20 +429,20 @@ class TestMain:
         ava_tags = {'vlan': [[10, 4095]]}
         tag_ranges = {'vlan': [[5, 4095]]}
         special_available_tags = {'vlan': ["untagged", "any"]}
-        special_tag_range = {'vlan': ["untagged", "any"]}
+        special_tags = {'vlan': ["untagged", "any"]}
         interface_details = [{
             "id": mock_interface_a.id,
             "available_tags": ava_tags,
             "tag_ranges": tag_ranges,
             "special_available_tags": special_available_tags,
-            "special_tag_range": special_tag_range
+            "special_tags": special_tags
         }]
         self.napp.load_interfaces_tags_values(mock_switch_a,
                                               interface_details)
         set_method = mock_interface_a.set_available_tags_tag_ranges
         set_method.assert_called_once_with(
             ava_tags, tag_ranges,
-            special_available_tags, special_tag_range
+            special_available_tags, special_tags
         )
 
     def test_handle_on_interface_tags(self):
@@ -456,7 +456,7 @@ class TestMain:
         mock_interface_a.available_tags = available_tags
         mock_interface_a.tag_ranges = tag_ranges
         mock_interface_a.special_available_tags = special_available_tags
-        mock_interface_a.special_tag_range = special_available_tags
+        mock_interface_a.special_tags = special_available_tags
         self.napp.handle_on_interface_tags(mock_interface_a)
         tp_controller = self.napp.topo_controller
         args = tp_controller.upsert_interface_details.call_args[0]
@@ -1779,7 +1779,7 @@ class TestMain:
         interface.tag_ranges = tags
         interface.available_tags = tags
         interface.special_available_tags = special_tags
-        interface.special_tag_range = special_tags
+        interface.special_tags = special_tags
         switch.interfaces = {1: interface}
         self.napp.controller.switches = {dpid: switch}
         url = f"{self.base_endpoint}/interfaces/tag_ranges"
@@ -1788,7 +1788,7 @@ class TestMain:
             'available_tags': tags,
             'tag_ranges': tags,
             'special_available_tags': special_tags,
-            'special_tag_range': special_tags
+            'special_tags': special_tags
         }}
         assert response.status_code == 200
         assert response.json() == expected
@@ -1804,7 +1804,7 @@ class TestMain:
         interface.tag_ranges = tags
         interface.available_tags = tags
         interface.special_available_tags = special_tags
-        interface.special_tag_range = special_tags
+        interface.special_tags = special_tags
         self.napp.controller.get_interface_by_id = MagicMock()
         self.napp.controller.get_interface_by_id.return_value = interface
         url = f"{self.base_endpoint}/interfaces/{dpid}:1/tag_ranges"
@@ -1814,7 +1814,7 @@ class TestMain:
                 "available_tags": tags,
                 "tag_ranges": tags,
                 'special_available_tags': special_tags,
-                'special_tag_range': special_tags
+                'special_tags': special_tags
             }
         }
         assert response.status_code == 200
@@ -1829,3 +1829,28 @@ class TestMain:
         url = f"{self.base_endpoint}/interfaces/{dpid}:1/tag_ranges"
         response = await self.api_client.get(url)
         assert response.status_code == 404
+
+    async def test_set_special_tags(self, event_loop):
+        """Test set_special_tags"""
+        self.napp.controller.loop = event_loop
+        interface_id = '00:00:00:00:00:00:00:01:1'
+        dpid = '00:00:00:00:00:00:00:01'
+        mock_switch = get_switch_mock(dpid)
+        mock_interface = get_interface_mock('s1-eth1', 1, mock_switch)
+        mock_interface.set_special_tagss = MagicMock()
+        self.napp.handle_on_interface_tags = MagicMock()
+        self.napp.controller.get_interface_by_id = MagicMock()
+        self.napp.controller.get_interface_by_id.return_value = mock_interface
+        payload = {
+            "tag_type": "vlan",
+            "special_tags": ["untagged"],
+        }
+        url = f"{self.base_endpoint}/interfaces/{interface_id}/"\
+              "special_tags"
+        response = await self.api_client.post(url, json=payload)
+        assert response.status_code == 200
+
+        args = mock_interface.set_special_tagss.call_args[0]
+        assert args[0] == payload["tag_type"]
+        assert args[1] == payload['special_tags']
+        assert self.napp.handle_on_interface_tags.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -428,25 +428,31 @@ class TestMain:
         mock_switch_a.interfaces = {1: mock_interface_a}
         ava_tags = {'vlan': [[10, 4095]]}
         tag_ranges = {'vlan': [[5, 4095]]}
+        special_available_tags = {'vlan': ["untagged", "any"]}
         interface_details = [{
             "id": mock_interface_a.id,
             "available_tags": ava_tags,
-            "tag_ranges": tag_ranges
+            "tag_ranges": tag_ranges,
+            "special_available_tags": special_available_tags
         }]
         self.napp.load_interfaces_tags_values(mock_switch_a,
                                               interface_details)
         set_method = mock_interface_a.set_available_tags_tag_ranges
-        set_method.assert_called_once_with(ava_tags, tag_ranges)
+        set_method.assert_called_once_with(
+            ava_tags, tag_ranges, special_available_tags
+        )
 
     def test_handle_on_interface_tags(self):
         """test_handle_on_interface_tags."""
         dpid_a = "00:00:00:00:00:00:00:01"
         available_tags = {'vlan': [[200, 3000]]}
         tag_ranges = {'vlan': [[20, 20], [200, 3000]]}
+        special_available_tags = {'vlan': ["untagged", "any"]}
         mock_switch_a = get_switch_mock(dpid_a, 0x04)
         mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
         mock_interface_a.available_tags = available_tags
         mock_interface_a.tag_ranges = tag_ranges
+        mock_interface_a.special_available_tags = special_available_tags
         self.napp.handle_on_interface_tags(mock_interface_a)
         tp_controller = self.napp.topo_controller
         args = tp_controller.upsert_interface_details.call_args[0]

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -197,8 +197,9 @@ class TestTopoController:
         id_ = "intf_id"
         available_tags = {'vlan': [[10, 4095]]}
         tag_ranges = {'vlan': [[5, 4095]]}
+        special_available_tags = {'vlan': ["untagged", "any"]}
         self.topo.upsert_interface_details(
-            id_, available_tags, tag_ranges
+            id_, available_tags, tag_ranges, special_available_tags
         )
         arg = self.topo.db.interface_details.find_one_and_update.call_args[0]
         assert arg[0] == {"_id": id_}

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -199,7 +199,8 @@ class TestTopoController:
         tag_ranges = {'vlan': [[5, 4095]]}
         special_available_tags = {'vlan': ["untagged", "any"]}
         self.topo.upsert_interface_details(
-            id_, available_tags, tag_ranges, special_available_tags
+            id_, available_tags, tag_ranges,
+            special_available_tags, special_available_tags
         )
         arg = self.topo.db.interface_details.find_one_and_update.call_args[0]
         assert arg[0] == {"_id": id_}


### PR DESCRIPTION
Closes #177 

### Summary
Added `special_available_tags` to `interface_details`
Related kytos [PR](https://github.com/kytos-ng/kytos/pull/431)

### Local Tests
Added unit tests
Create EVCs with special vlans and restarted kytos

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X.....F..... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 47%]
tests/test_e2e_15_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 72%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 75%]
tests/test_e2e_40_sdntrace.py .............                              [ 80%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_42_sdntrace.py ..                                         [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```

Error from `test_190_post_an_evc_twice()` because the EVC has no tag. Looking into it.
[Issue](https://github.com/kytos-ng/mef_eline/issues/410) created. This is `mef_eline` only issue