### PR TITLE
fix: handled deactivated interface when an interface gets created.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Removed
 Fixed
 =====
 - An interface cannot be enabled if its switch is disabled.
+- Handled deactivated interfaces when an interface gets created.
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -933,8 +933,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """
         interface = event.content['interface']
         if not interface.is_active():
-            return
-        self.handle_interface_link_up(interface, event)
+            self.handle_interface_link_down(interface, event)
+        else:
+            self.handle_interface_link_up(interface, event)
 
     @listen_to('.*.topology.switch.interface.created')
     def on_interface_created(self, event):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1184,8 +1184,9 @@ class TestMain:
         self.napp.handle_connection_lost(mock_event)
         mock_notify_topology_update.assert_called()
 
+    @patch('napps.kytos.topology.main.Main.handle_interface_link_down')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_up')
-    def test_handle_interface_created(self, mock_link_up):
+    def test_handle_interface_created(self, mock_link_up, mock_link_down):
         """Test handle_interface_created."""
         mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
@@ -1193,9 +1194,12 @@ class TestMain:
         mock_event.content = {'interface': mock_interface}
         self.napp.handle_interface_created(mock_event)
         mock_link_up.assert_called()
+        mock_link_down.assert_not_called()
 
+    @patch('napps.kytos.topology.main.Main.handle_interface_link_down')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_up')
-    def test_handle_interface_created_inactive(self, mock_link_up):
+    def test_handle_interface_created_inactive(self, mock_link_up,
+                                               mock_link_down):
         """Test handle_interface_created inactive."""
         mock_event = MagicMock()
         mock_interface = create_autospec(Interface)
@@ -1204,6 +1208,7 @@ class TestMain:
         mock_interface.is_active.return_value = False
         self.napp.handle_interface_created(mock_event)
         mock_link_up.assert_not_called()
+        mock_link_down.assert_called()
 
     def test_handle_interfaces_created(self):
         """Test handle_interfaces_created."""


### PR DESCRIPTION
Closes #186 

### Summary

See updated changelog file 

### Local Tests

I repeated the same test mentioned on issue 186, no longer the problem happens, notice below as soon as the switch reconnects the link_down gets notified now if an interface is deactivated when a switch is disabled:

```
kytos $> 2024-03-01 14:18:11,771 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:36958. Reason: Request closed by client                              
2024-03-01 14:18:16,106 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:36962. Reason: Request closed by client
kytos $>                                                                                                                                                                                 

kytos $> 2024-03-01 14:18:23,654 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42190 - "GET /api/kytos/topology/v3/ HTTP/1.1" 200                                                       
2024-03-01 14:18:54,258 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:47684
2024-03-01 14:18:54,676 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_14) Connection ('127.0.0.1', 47684), Switch 00:00:00:00:00:00:00:03: OPENFLOW HANDSHAKE COMPLETE
2024-03-01 14:18:54,689 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth
3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-03-01 14:18:54,696 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51032 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&cookie_range=12321848580485677056&cookie_rang
e=12393906174523604991&dpid=00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 200
kytos $>                                                                                                                                                                                 

kytos $> 2024-03-01 14:19:06,516 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:42310                                                                        
2024-03-01 14:19:06,691 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_12) Connection ('127.0.0.1', 42310), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2024-03-01 14:19:06,709 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37638 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&cookie_range=12321848580485677056&cookie_rang
e=12393906174523604991&dpid=00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 200
kytos $>                                                                                                                                                                                 

kytos $> 2024-03-01 14:19:22,784 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38074 - "GET /api/kytos/topology/v3/ HTTP/1.1" 200                                                       
2024-03-01 14:19:32,088 - INFO [uvicorn.access] (MainThread) 127.0.0.1:46400 - "GET /api/kytos/topology/v3/ HTTP/1.1" 200
kytos $>                                                                                                                                                                                 

kytos $> # now I'll activate s1-eth4 in the switch                                                                                                                                       

kytos $> 2024-03-01 14:20:05,237 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE                                
2024-03-01 14:20:05,238 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2024-03-01 14:20:08,244 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_2) Event handle_link_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth3
', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
kytos $>                                                                                                                                                                                 

kytos $> 2024-03-01 14:20:13,954 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58222 - "GET /api/kytos/topology/v3/ HTTP/1.1" 200                                                       
kytos $>                                                                                                                                                                                 


```

- I also ran a link flap stress test, no issues have been observed:

```
link_flap test iteration 0
[sudo] password for viniarck: 
         waiting for 10 secs before next iteration
link_flap test iteration 1
         waiting for 10 secs before next iteration
link_flap test iteration 2
         waiting for 10 secs before next iteration
link_flap test iteration 3
         waiting for 10 secs before next iteration
link_flap test iteration 4
         waiting for 10 secs before next iteration
```

### End-to-End Tests

Exec with this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 261 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py .....................                  [ 55%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 237 passed, 8 skipped, 9 xfailed, 7 xpassed, 1143 warnings in 12211.93s (3:23:31) =
```