### PR TITLE
feat: added links activation consistency check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 - Added endpoint ``DELETE /v3/switches/{dpid}`` to delete a disabled switch. This endpoint is for decommissioned switches. The switch will get rediscovered if it reconnects to the controller. So, after deleting a switch on ``topology``, you're expected to also remove the TCP connection configuration on the switch.
 - Added ``Delete`` button to delete switch in the switch panel UI interface.
 - Added ``Delete`` button to delete link in the link panel UI interface.
+- Added links activation consistency check, and exposed ``CONSISTENCY_LINK_INTERVAL`` and ``CONSISTENCY_LINK_MIN_COUNT`` on settings.
 
 Deprecated
 ==========

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                                   self.link_status_hook_link_up_timer)
         self.topo_controller.bootstrap_indexes()
         self.load_topology()
-        self.execute_as_loop(settings.CONSISTENCY_INTERVAL)
+        self.execute_as_loop(settings.CONSISTENCY_LINK_INTERVAL)
 
     @staticmethod
     def get_topo_controller() -> TopoController:
@@ -244,7 +244,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                     continue
 
                 self._links_act_ccheck[link.id] += 1
-                min_count = settings.CONSISTENCY_MIN_COUNT
+                min_count = settings.CONSISTENCY_LINK_MIN_COUNT
                 if self._links_act_ccheck[link.id] >= min_count:
                     inconsistent_links.append(link)
 

--- a/settings.py
+++ b/settings.py
@@ -8,3 +8,10 @@ LINK_UP_TIMER = 10
 
 # Base URL of the Flow Manager endpoint
 FLOW_MANAGER_URL = "http://localhost:8181/api/kytos/flow_manager/v2"
+
+# This is for checking link active state consistency with its interfaces.
+# It's recommended that CONSISTENCY_INTERVAL is greater than LINK_UP_TIMER
+# and CONSISTENCY_MIN_COUNT is greater than 1 just so the standard link
+# activation path has always a chance to run first
+CONSISTENCY_INTERVAL = 15
+CONSISTENCY_MIN_COUNT = 2

--- a/settings.py
+++ b/settings.py
@@ -13,5 +13,5 @@ FLOW_MANAGER_URL = "http://localhost:8181/api/kytos/flow_manager/v2"
 # It's recommended that CONSISTENCY_INTERVAL is greater than LINK_UP_TIMER
 # and CONSISTENCY_MIN_COUNT is greater than 1 just so the standard link
 # activation path has always a chance to run first
-CONSISTENCY_INTERVAL = 15
-CONSISTENCY_MIN_COUNT = 2
+CONSISTENCY_LINK_INTERVAL = 15
+CONSISTENCY_LINK_MIN_COUNT = 2


### PR DESCRIPTION
Closes #188, this PR is on top of PR #187

This PR is still a draft, I'm still exploring it locally, and I need to also finish unit test, but overall the implementation is in place. I'm checking if I find any other issues before shipping the unit tests

### Summary

See updated changelog file 

### Local Tests

- I simulated a link deactivated with its interfaces UP, and the consistency check activated it:

```
kytos $> str(datetime.now())                                                                                                                                                            
Out[8]: '2024-03-01 16:30:39.510118'

kytos $> links[link_id].deactivate()                                                                                                                                                    

kytos $> 2024-03-01 16:31:08,307 - INFO [kytos.napps.kytos/topology] (topology) consistency check: activated Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface(
's3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
2024-03-01 16:31:18,317 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_0) Event handle_link_up Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth
2', 2, Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
kytos $>                                                                                                                                                                                

kytos $>                                                                                                                                                                                
```

### End-to-End Tests

Exec with this branch:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 261 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py .....................                  [ 55%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 237 passed, 8 skipped, 9 xfailed, 7 xpassed, 1143 warnings in 12202.58s (3:23:22) =
```