### PR TITLE
fix: allowed interface speed to be null on switches collection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Fixed
 =====
 - An interface cannot be enabled if its switch is disabled.
 - Handled deactivated interfaces when an interface gets created.
+- Allowed interface speed to be null on ``switches`` collection
 
 Security
 ========

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -31,7 +31,7 @@ class InterfaceSubDoc(BaseModel):
     id: str
     enabled: bool
     mac: str
-    speed: float
+    speed: Optional[float]
     port_number: int
     name: str
     nni: bool = False

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -46,6 +46,35 @@ def test_switch_doc_preset_interfaces() -> None:
     assert interface_id == model.interfaces[0].id
 
 
+def test_switch_doc_preset_interfaces_speed_none() -> None:
+    """test_switch_doc_preset_interfaces speed none."""
+    dpid = "00:00:00:00:00:00:00:01"
+    interface_id = f"{dpid}:1"
+    interfaces = {
+        interface_id: {
+            "id": interface_id,
+            "port_number": 1,
+            "lldp": True,
+            "enabled": True,
+            "active": True,
+            "mac": "some_mac",
+            "speed": None,
+            "name": "some_name",
+            "switch": dpid,
+        }
+    }
+    payload = {
+        "_id": dpid,
+        "enabled": True,
+        "active": True,
+        "interfaces": interfaces,
+    }
+    model = SwitchDoc(**payload)
+    assert model
+    assert interface_id == model.interfaces[0].id
+    assert model.interfaces[0].speed is None
+
+
 def test_switch_doc_no_preset_interfaces() -> None:
     """test_switch_doc_no_preset_interfaces."""
     dpid = "00:00:00:00:00:00:00:01"


### PR DESCRIPTION
Related to https://github.com/kytos-ng/of_core/pull/133

This PR is on top of https://github.com/kytos-ng/topology/pull/187

### Summary

- This PR isn't absolutely needed since it's been fixed on of_core, and the existing paths before creating an interface will set it, but since on kytos runtime an [`Interface.speed` can still be None](https://github.com/kytos-ng/kytos/blob/master/kytos/core/interface.py#L688), then for completeness let's keep the DB model also supporting it. If one day a new southbound doesn't set it it also won't crash. 
- See updated changelog file

### Local Tests

Same as the tests mentioned on the linked PR

### End-to-End Tests

I'll dispatch an e2e exec with this branch and of_core's linked PR:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 261 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py .....................                  [ 55%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 237 passed, 8 skipped, 9 xfailed, 7 xpassed, 1143 warnings in 12383.73s (3:26:23) =
```
