### PR TITLE
Added interface deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,15 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Added endpoint ``DELETE v3/interfaces/{interface_id}`` to delete an interface.
+
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
 - Updated test dependencies
+- After ``*.*.switch.interface.deleted`` event, the interface, if not used, will be automatically removed from memory.
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -352,3 +352,9 @@ class TopoController:
             {"_id": switch_dpid}
         )
         return (swt_result, det_result.deleted_count)
+
+    def delete_interface_from_details(self, intf_id: str) -> Optional[dict]:
+        """Delete interface from interface_details."""
+        return self.db.interface_details.find_one_and_delete(
+            {"_id": intf_id}
+        )

--- a/main.py
+++ b/main.py
@@ -1012,9 +1012,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if interface.is_enabled() or interface.is_active():
             return "It is enabled or active."
 
-        if not interface.all_tags_available():
-            return "There is an allocated TAG."
-
         link = self._get_link_from_interface(interface)
         if link:
             return f"It has a link, {link.id}."
@@ -1033,6 +1030,16 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             in_port = flow["flow"].get("match", {}).get("in_port")
             if in_port == port_n:
                 return flow["flow_id"]
+
+            instructions = flow["flow"].get("instructions", [])
+            for instruction in instructions:
+                if instruction["instruction_type"] == "apply_actions":
+                    actions = instruction["actions"]
+                    for action in actions:
+                        if (action["action_type"] == "output"
+                                and action.get("port") == port_n):
+                            return flow["flow_id"]
+
             actions = flow["flow"].get("actions", [])
             for action in actions:
                 if (action["action_type"] == "output"

--- a/main.py
+++ b/main.py
@@ -804,15 +804,18 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         intf_id = request.path_params.get("intf_id")
         intf_split = intf_id.split(":")
         switch_id = ":".join(intf_split[:-1])
-        intf_port = int(intf_split[-1])
+        try:
+            intf_port = int(intf_split[-1])
+        except ValueError:
+            raise HTTPException(400, detail="Invalid interface id.")
         try:
             switch = self.controller.switches[switch_id]
         except KeyError:
-            raise HTTPException(404, detail="Switch not found")
+            raise HTTPException(404, detail="Switch not found.")
         try:
             interface = switch.interfaces[intf_port]
         except KeyError:
-            raise HTTPException(404, detail="Interface not found")
+            raise HTTPException(404, detail="Interface not found.")
 
         usage = self.get_intf_usage(interface)
         if usage:

--- a/main.py
+++ b/main.py
@@ -797,11 +797,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         event = KytosEvent(name=name, content={'link': link})
         self.controller.buffers.app.put(event)
         return JSONResponse("Operation successful")
-    
+
     @rest('v3/interfaces/{intf_id}', methods=['DELETE'])
     def delete_interface(self, request: Request) -> JSONResponse:
         """Delete an interface only if it is not used."""
-        intf_id:str = request.path_params.get("intf_id")
+        intf_id = request.path_params.get("intf_id")
         intf_split = intf_id.split(":")
         switch_id = ":".join(intf_split[:-1])
         intf_port = int(intf_split[-1])
@@ -1014,7 +1014,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
         if not interface.all_tags_available():
             return "There is an allocated TAG."
-        
+
         link = self._get_link_from_interface(interface)
         if link:
             return f"It has a link, {link.id}."
@@ -1036,13 +1036,13 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             actions = flow["flow"].get("actions", [])
             for action in actions:
                 if (action["action_type"] == "output"
-                    and action.get("port") == port_n):
+                        and action.get("port") == port_n):
                     return flow["flow_id"]
         return None
-    
+
     def _delete_interface(self, interface: Interface):
-        """Delete any trace of an interface. Only use this method when 
-        it was confirmed that the interface is not used."""
+        """Delete any trace of an interface. Only use this method when
+         it was confirmed that the interface is not used."""
         switch: Switch = interface.switch
         switch.remove_interface(interface)
         self.topo_controller.upsert_switch(switch.id, switch.as_dict())
@@ -1074,14 +1074,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         before_sleep=before_sleep,
         retry=retry_if_exception_type(httpx.RequestError),
     )
-    def get_flows_by_switch(self, dpid: str) -> dict:
+    def get_flows_by_switch(self, dpid: str) -> list:
         """Get installed flows by switch from flow_manager."""
         endpoint = settings.FLOW_MANAGER_URL +\
             f'/stored_flows?state=installed&dpid={dpid}'
         res = httpx.get(endpoint)
         if res.is_server_error or res.status_code in (404, 400):
             raise httpx.RequestError(res.text)
-        return res.json().get(dpid, {})
+        return res.json().get(dpid, [])
 
     def link_status_hook_link_up_timer(self, link) -> Optional[EntityStatus]:
         """Link status hook link up timer."""

--- a/main.py
+++ b/main.py
@@ -129,7 +129,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Return an object representing the topology."""
         return Topology(self.controller.switches.copy(), self.links.copy())
 
-    def _get_link_from_interface(self, interface):
+    def _get_link_from_interface(self, interface: Interface):
         """Return the link of the interface, or None if it does not exist."""
         for link in list(self.links.values()):
             if interface in (link.endpoint_a, link.endpoint_b):
@@ -797,6 +797,29 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         event = KytosEvent(name=name, content={'link': link})
         self.controller.buffers.app.put(event)
         return JSONResponse("Operation successful")
+    
+    @rest('v3/interfaces/{intf_id}', methods=['DELETE'])
+    def delete_interface(self, request: Request) -> JSONResponse:
+        """Delete an interface only if it is not used."""
+        intf_id:str = request.path_params.get("intf_id")
+        intf_split = intf_id.split(":")
+        switch_id = ":".join(intf_split[:-1])
+        intf_port = int(intf_split[-1])
+        try:
+            switch = self.controller.switches[switch_id]
+        except KeyError:
+            raise HTTPException(404, detail="Switch not found")
+        try:
+            interface = switch.interfaces[intf_port]
+        except KeyError:
+            raise HTTPException(404, detail="Interface not found")
+
+        usage = self.get_intf_usage(interface)
+        if usage:
+            raise HTTPException(409, detail=f"Interface could not be "
+                                            f"deleted. Reason: {usage}")
+        self._delete_interface(interface)
+        return JSONResponse("Operation Successful", status_code=200)
 
     @listen_to("kytos/.*.liveness.(up|down)")
     def on_link_liveness_status(self, event) -> None:
@@ -975,6 +998,55 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_interface_deleted(self, event):
         """Update the topology based on a Port Delete event."""
         self.handle_interface_down(event)
+        interface = event.content['interface']
+        usage = self.get_intf_usage(interface)
+        if usage:
+            log.info(f"Interface {interface.id} could not be safely removed."
+                     f" Reason: {usage}")
+        else:
+            self._delete_interface(interface)
+
+    def get_intf_usage(self, interface: Interface) -> Optional[str]:
+        """Determines how an interface is used explained in a string,
+        returns None if unused."""
+        if interface.is_enabled() or interface.is_active():
+            return "It is enabled or active."
+
+        if not interface.all_tags_available():
+            return "There is an allocated TAG."
+        
+        link = self._get_link_from_interface(interface)
+        if link:
+            return f"It has a link, {link.id}."
+
+        flow_id = self.get_flow_id_by_intf(interface)
+        if flow_id:
+            return f"There is a flow installed, {flow_id}."
+
+        return None
+
+    def get_flow_id_by_intf(self, interface: Interface) -> str:
+        """Return flow_id from first found flow used by interface."""
+        flows = self.get_flows_by_switch(interface.switch.id)
+        port_n = int(interface.id.split(":")[-1])
+        for flow in flows:
+            in_port = flow["flow"].get("match", {}).get("in_port")
+            if in_port == port_n:
+                return flow["flow_id"]
+            actions = flow["flow"].get("actions", [])
+            for action in actions:
+                if (action["action_type"] == "output"
+                    and action.get("port") == port_n):
+                    return flow["flow_id"]
+        return None
+    
+    def _delete_interface(self, interface: Interface):
+        """Delete any trace of an interface. Only use this method when 
+        it was confirmed that the interface is not used."""
+        switch: Switch = interface.switch
+        switch.remove_interface(interface)
+        self.topo_controller.upsert_switch(switch.id, switch.as_dict())
+        self.topo_controller.delete_interface_from_details(interface.id)
 
     @listen_to('.*.switch.interface.link_up')
     def on_interface_link_up(self, event):
@@ -1002,14 +1074,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         before_sleep=before_sleep,
         retry=retry_if_exception_type(httpx.RequestError),
     )
-    def get_flows_by_switch(self, dpid) -> dict:
+    def get_flows_by_switch(self, dpid: str) -> dict:
         """Get installed flows by switch from flow_manager."""
         endpoint = settings.FLOW_MANAGER_URL +\
             f'/stored_flows?state=installed&dpid={dpid}'
         res = httpx.get(endpoint)
         if res.is_server_error or res.status_code in (404, 400):
             raise httpx.RequestError(res.text)
-        return res.json().get(dpid)
+        return res.json().get(dpid, {})
 
     def link_status_hook_link_up_timer(self, link) -> Optional[EntityStatus]:
         """Link status hook link up timer."""

--- a/openapi.yml
+++ b/openapi.yml
@@ -262,6 +262,13 @@ paths:
               schema:
                 type: string
                 example: Operation sucessful
+        400:
+          description: The interface id is invalid.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Invalid interface id.
         404:
           description: Interface does not exist.
           content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -62,7 +62,21 @@ paths:
             application/json:
               schema:
                 type: string
-                example: Switch not found
+                example: Operation sucessful
+        404:
+          description: Switch does not exist.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Switch not found.
+        409:
+          description: Switch could not be deleted because is used.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Switch has flows. Verify if a switch is used.
   /v3/switches/{dpid}/enable:
     post:
       summary: Administratively enable a switch in the topology.
@@ -227,6 +241,41 @@ paths:
                     type: object
                     additionalProperties:
                       $ref: '#/components/schemas/Interface'
+
+  /v3/interfaces/{interface_id}:
+    delete:
+      summary: Delete an interface.
+      description: Delete an interface that is not being used.
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: Interface ID.
+          in: path
+          example: 00:00:00:00:00:00:00:01:1
+      responses:
+        200:
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Operation sucessful
+        404:
+          description: Interface does not exist.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Interface not found
+        409:
+          description: Interface could not be deleted.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Interface could not be deleted. Reason; It is enabled or active.
 
   /v3/interfaces/{interface_id}/enable:
     post:

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -97,9 +97,17 @@ class TestMain:
         interface.switch.dpid = "00:00:00:00:00:00:00:01"
         stats_event = KytosEvent(name=event_name,
                                  content={'interface': interface})
+        self.napp.get_intf_usage = MagicMock(return_value="Usage")
         self.napp.handle_interface_deleted(stats_event)
         event_updated_response = self.napp.controller.buffers.app.get()
         assert event_updated_response.name == 'kytos/topology.updated'
+
+        self.napp.get_intf_usage.return_value = None
+        self.napp._delete_interface = MagicMock()
+        self.napp.handle_interface_deleted(stats_event)
+        event_updated_response = self.napp.controller.buffers.app.get()
+        assert event_updated_response.name == 'kytos/topology.updated'
+        assert self.napp._delete_interface.call_count == 1
 
     async def test_handle_connection_lost(self):
         """Test handle connection lost."""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -89,7 +89,8 @@ class TestMain:
         event_response = self.napp.controller.buffers.app.get()
         assert event_response.name == 'kytos/topology.updated'
 
-    async def test_handle_interface_deleted(self):
+    @patch('napps.kytos.topology.main.log')
+    async def test_handle_interface_deleted(self, mock_log):
         """Test handle interface deleted."""
         self.napp.controller._buffers = KytosBuffers()
         event_name = '.*.switch.interface.deleted'
@@ -98,12 +99,14 @@ class TestMain:
         stats_event = KytosEvent(name=event_name,
                                  content={'interface': interface})
         self.napp.get_intf_usage = MagicMock(return_value="Usage")
+        self.napp._delete_interface = MagicMock()
         self.napp.handle_interface_deleted(stats_event)
         event_updated_response = self.napp.controller.buffers.app.get()
         assert event_updated_response.name == 'kytos/topology.updated'
+        assert not self.napp._delete_interface.call_count
+        assert mock_log.info.call_count == 1
 
         self.napp.get_intf_usage.return_value = None
-        self.napp._delete_interface = MagicMock()
         self.napp.handle_interface_deleted(stats_event)
         event_updated_response = self.napp.controller.buffers.app.get()
         assert event_updated_response.name == 'kytos/topology.updated'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2081,6 +2081,11 @@ class TestMain:
         switch_id = "00:00:00:00:00:00:00:01"
         intf_id = "00:00:00:00:00:00:00:01:1"
 
+        # Error 400 Invalid interface id
+        endpoint = f"{self.base_endpoint}/interfaces/{intf_id}x"
+        response = await self.api_client.delete(endpoint)
+        assert response.status_code == 400, response
+
         # Error 404 Switch not found
         endpoint = f"{self.base_endpoint}/interfaces/{intf_id}"
         response = await self.api_client.delete(endpoint)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2118,11 +2118,6 @@ class TestMain:
         assert actual_usage == "It is enabled or active."
 
         mock_intf.is_active.return_value = False
-        mock_intf.all_tags_available.return_value = False
-        actual_usage = self.napp.get_intf_usage(mock_intf)
-        assert actual_usage == "There is an allocated TAG."
-
-        mock_intf.all_tags_available.return_value = True
         self.napp._get_link_from_interface = MagicMock(return_value=Mock())
         actual_usage = self.napp.get_intf_usage(mock_intf)
         assert "It has a link," in actual_usage
@@ -2154,9 +2149,18 @@ class TestMain:
             },
             {
                 "flow": {
-                    "match": {"dl_src": "ee:ee:ee:ee:ee:02"},
+                    "instructions": [{
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "output", "port": 1}]
+                    }]
                 },
                 "flow_id": "flow_2",
+            },
+            {
+                "flow": {
+                    "match": {"dl_src": "ee:ee:ee:ee:ee:02"},
+                },
+                "flow_id": "flow_3",
             }
         ]
 
@@ -2173,6 +2177,10 @@ class TestMain:
         assert flow_id == flows[1]["flow_id"]
 
         mock_flows.return_value = [flows[2]]
+        flow_id = self.napp.get_flow_id_by_intf(mock_intf)
+        assert flow_id == flows[2]["flow_id"]
+
+        mock_flows.return_value = [flows[3]]
         flow_id = self.napp.get_flow_id_by_intf(mock_intf)
         assert flow_id is None
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2073,3 +2073,116 @@ class TestMain:
         mock_get.return_value.json.return_value = expected
         actual = self.napp.get_flows_by_switch(dpid)
         assert actual == "mocked_flows"
+
+    @patch('napps.kytos.topology.main.Main.get_intf_usage')
+    @patch('napps.kytos.topology.main.Main._delete_interface')
+    async def test_delete_interface_api(self, mock_delete, mock_usage):
+        """Test delete interface API call"""
+        switch_id = "00:00:00:00:00:00:00:01"
+        intf_id = "00:00:00:00:00:00:00:01:1"
+
+        # Error 404 Switch not found
+        endpoint = f"{self.base_endpoint}/interfaces/{intf_id}"
+        response = await self.api_client.delete(endpoint)
+        assert response.status_code == 404, response
+
+        # Error 404 Interface not found
+        mock_switch = get_switch_mock(switch_id)
+        mock_switch.interfaces = {}
+        self.napp.controller.switches = {switch_id: mock_switch}
+        response = await self.api_client.delete(endpoint)
+        assert response.status_code == 404, response
+
+        # Error 409 Interface is used
+        mock_switch.interfaces = {1: Mock()}
+        self.napp.controller.switches = {switch_id: mock_switch}
+        mock_usage.return_value = "There is an allocated TAG."
+        response = await self.api_client.delete(endpoint)
+        assert response.status_code == 409, response
+
+        # Success
+        mock_usage.return_value = None
+        mock_delete.return_value = True
+        response = await self.api_client.delete(endpoint)
+        assert response.status_code == 200, response
+
+    def test_get_intf_usage(self):
+        """Test get_intf_usage"""
+        switch_id = "00:00:00:00:00:00:00:01"
+        mock_switch = get_switch_mock(switch_id)
+        mock_intf = get_interface_mock('s1-eth1', 1, mock_switch)
+
+        mock_intf.is_enabled.return_value = False
+        mock_intf.is_active.return_value = True
+        actual_usage = self.napp.get_intf_usage(mock_intf)
+        assert actual_usage == "It is enabled or active."
+
+        mock_intf.is_active.return_value = False
+        mock_intf.all_tags_available.return_value = False
+        actual_usage = self.napp.get_intf_usage(mock_intf)
+        assert actual_usage == "There is an allocated TAG."
+
+        mock_intf.all_tags_available.return_value = True
+        self.napp._get_link_from_interface = MagicMock(return_value=Mock())
+        actual_usage = self.napp.get_intf_usage(mock_intf)
+        assert "It has a link," in actual_usage
+
+        self.napp._get_link_from_interface.return_value = None
+        self.napp.get_flow_id_by_intf = MagicMock(return_value="mock_flow")
+        actual_usage = self.napp.get_intf_usage(mock_intf)
+        assert "There is a flow installed" in actual_usage
+
+        self.napp.get_flow_id_by_intf.return_value = None
+        actual_usage = self.napp.get_intf_usage(mock_intf)
+        assert actual_usage is None
+
+    @patch('napps.kytos.topology.main.Main.get_flows_by_switch')
+    def test_get_flow_id_by_intf(self, mock_flows):
+        """Test get_flow_id_by_intf"""
+        flows = [
+            {
+                "flow": {
+                    "match": {"in_port": 1, "dl_vlan": 200},
+                },
+                "flow_id": "flow_0",
+            },
+            {
+                "flow": {
+                    "actions": [{"action_type": "output", "port": 1}]
+                },
+                "flow_id": "flow_1",
+            },
+            {
+                "flow": {
+                    "match": {"dl_src": "ee:ee:ee:ee:ee:02"},
+                },
+                "flow_id": "flow_2",
+            }
+        ]
+
+        switch_id = "00:00:00:00:00:00:00:01"
+        mock_switch = get_switch_mock(switch_id)
+        mock_intf = get_interface_mock('s1-eth1', 1, mock_switch)
+
+        mock_flows.return_value = [flows[0]]
+        flow_id = self.napp.get_flow_id_by_intf(mock_intf)
+        assert flow_id == flows[0]["flow_id"]
+
+        mock_flows.return_value = [flows[1]]
+        flow_id = self.napp.get_flow_id_by_intf(mock_intf)
+        assert flow_id == flows[1]["flow_id"]
+
+        mock_flows.return_value = [flows[2]]
+        flow_id = self.napp.get_flow_id_by_intf(mock_intf)
+        assert flow_id is None
+
+    def test_delete_interface(self):
+        """Test _delete_interface"""
+        switch_id = "00:00:00:00:00:00:00:01"
+        mock_switch = get_switch_mock(switch_id)
+        mock_intf = get_interface_mock('s1-eth1', 1, mock_switch)
+        self.napp._delete_interface(mock_intf)
+        assert mock_switch.remove_interface.call_count == 1
+        assert self.napp.topo_controller.upsert_switch.call_count == 1
+        delete = self.napp.topo_controller.delete_interface_from_details
+        assert delete.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2096,7 +2096,7 @@ class TestMain:
         # Error 409 Interface is used
         mock_switch.interfaces = {1: Mock()}
         self.napp.controller.switches = {switch_id: mock_switch}
-        mock_usage.return_value = "There is an allocated TAG."
+        mock_usage.return_value = "It is enabled or active."
         response = await self.api_client.delete(endpoint)
         assert response.status_code == 409, response
 

--- a/tests/unit/test_topo_controller.py
+++ b/tests/unit/test_topo_controller.py
@@ -263,3 +263,11 @@ class TestTopoController:
         assert self.topo.db.links.bulk_write.call_count == 1
         args = self.topo.db.links.bulk_write.call_args[0]
         assert len(args[0]) == 2
+
+    def test_delete_interface_from_details(self) -> None:
+        """Test delete_interface_from_details"""
+        self.topo.delete_interface_from_details("mock_intf")
+        intf_details = self.topo.db.interface_details
+        assert intf_details.find_one_and_delete.call_count == 1
+        args = intf_details.find_one_and_delete.call_args[0]
+        assert args[0] == {"_id": "mock_intf"}


### PR DESCRIPTION
Closes #191

### Summary

Added API request to delete interface `DELETE api/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:01:1`.
After the `*.*.switch.interface.deleted` event, the interface can be deleted from memory if it is not used.

### Local Tests
To delete interface, it needs to be removed from OVS: `sudo ip link delete s1-eth4`
Also:
- It is inactive and disabled.
- It does not have a link.
- There should not be an installed flow related to the interface (actions `output`, instructions `apply_action` and match `in_port`).

### End-to-End Tests
TBA
