### PR TITLE
Moved controller method inside lock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.1] - 2024-08-23
+***********************
+
+Fixed
+=====
+- Update ``interface_detail`` document in the DB can handle multiple and fast changes.
+  
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -891,7 +891,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_tags_updated_at[interface.id] = event.timestamp
-        self.handle_on_interface_tags(interface)
+            self.handle_on_interface_tags(interface)
 
     def handle_on_interface_tags(self, interface):
         """Update interface details"""

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ class Test(TestCommand):
 
     def run(self):
         """Run tests."""
-        cmd = f"python3 -m pytest tests/ {self.get_args()}"
+        cmd = "python3 -m pytest tests/ --cov-report term-missing"
+        cmd += f" {self.get_args()}"
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -113,7 +114,8 @@ class TestCoverage(Test):
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = f"python3 -m pytest --cov=. tests/ {self.get_args()}"
+        cmd = "python3 -m pytest --cov=. tests/ --cov-report term-missing"
+        cmd += f" {self.get_args()}"
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:


### PR DESCRIPTION
Closes #205 

### Summary

To duplicate the issue with a high rate of success, this method is needed inside the class `Interface`:
```
    def testing3(self, controller, n):
        for i in range(n):
            self.available_tags = {"vlan": [[i, 4095]]}
            self._notify_interface_tags(controller)
```

And this can be called from kytos console preferably with a high value number:
```
controller.switches['00:00:00:00:00:00:00:01'].interfaces[1].testing3(controller, 200)
```
Also, only works after a kytos shutdown. It has to be a fresh start.

### Local Tests
Performed the above test multiple times

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```

### Extra
The logs mismatch with from mongo result and database values also happened with the test above.
