### PR TITLE
hotfix 2024.1.2: increased acquired lock scope when handling link up|down 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.2] - 2024-09-10
+***********************
+
+Fixed
+=====
+- Fixed link down thread safety notification issue
+
+Added
+=====
+- Included link changed status log info for correlation
+
 [2024.1.1] - 2024-08-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -52,7 +52,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                                      DEFAULT_LINK_UP_TIMER)
 
         self._links_lock = Lock()
-        self._links_notify_lock = defaultdict(Lock)
         # to keep track of potential unorded scheduled interface events
         self._intfs_lock = defaultdict(Lock)
         self._intfs_updated_at = {}
@@ -989,7 +988,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_updated_at[interface.id] = event.timestamp
-        interface.deactivate()
+            interface.deactivate()
         self.handle_interface_link_down(interface, event)
 
     @listen_to('.*.switch.interface.deleted')
@@ -1075,7 +1074,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_updated_at[interface.id] = event.timestamp
-        self.handle_link_up(interface)
+            self.handle_link_up(interface)
 
     @tenacity.retry(
         stop=stop_after_attempt(3),
@@ -1111,7 +1110,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         time.sleep(self.link_up_timer)
         if link.status != EntityStatus.UP:
             return
-        with self._links_notify_lock[link.id]:
+        with self._links_lock:
             notified_at = link.get_metadata("notified_up_at")
             if (
                 notified_at
@@ -1145,7 +1144,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.extend_metadata(metadata)
             link.activate()
             self.notify_topology_update()
-        self.notify_link_up_if_status(link, "link up")
+            event = KytosEvent(
+                name="kytos/topology.notify_link_up_if_status",
+                content={"reason": "link up", "link": link}
+            )
+            self.controller.buffers.app.put(event)
 
     @listen_to('.*.switch.interface.link_down')
     def on_interface_link_down(self, event):
@@ -1165,7 +1168,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_updated_at[interface.id] = event.timestamp
-        self.handle_link_down(interface)
+            self.handle_link_down(interface)
 
     def handle_link_down(self, interface):
         """Notify a link is down."""

--- a/main.py
+++ b/main.py
@@ -1312,6 +1312,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 (not link.status_reason and link.status == EntityStatus.UP)
                 and link_id not in self.link_up
             ):
+                log.info(f"{link} changed status {link.status}, "
+                         f"reason: {reason}")
                 self.link_up.add(link_id)
                 event = KytosEvent(
                     name='kytos/topology.link_up',
@@ -1324,6 +1326,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 (link.status_reason or link.status != EntityStatus.UP)
                 and link_id in self.link_up
             ):
+                log.info(f"{link} changed status {link.status}, "
+                         f"reason: {reason}")
                 self.link_up.remove(link_id)
                 event = KytosEvent(
                     name='kytos/topology.link_down',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1245,12 +1245,10 @@ class TestMain:
         mock_handle_interface_link_down.assert_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
-    @patch('napps.kytos.topology.main.Main.notify_link_up_if_status')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     def test_interface_link_up(self, *args):
         """Test interface link_up."""
         (mock_notify_topology_update,
-         mock_notify_link_up_if_status,
          mock_link_from_interface) = args
 
         tnow = time.time()
@@ -1270,7 +1268,9 @@ class TestMain:
         mock_notify_topology_update.assert_called()
         mock_link.extend_metadata.assert_called()
         mock_link.activate.assert_called()
-        mock_notify_link_up_if_status.assert_called()
+        assert self.napp.controller.buffers.app.put.call_count == 2
+        ev = "kytos/topology.notify_link_up_if_status"
+        assert self.napp.controller.buffers.app.put.call_args[0][0].name == ev
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
@@ -1375,12 +1375,10 @@ class TestMain:
         mock_status_change.assert_called()
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
-    @patch('napps.kytos.topology.main.Main.notify_link_up_if_status')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     def test_handle_link_up(self, *args):
         """Test handle link up."""
         (mock_notify_topology_update,
-         mock_notify_link_up_if_status,
          mock_link_from_interface) = args
 
         mock_interface = create_autospec(Interface)
@@ -1389,8 +1387,10 @@ class TestMain:
         mock_link_from_interface.return_value = mock_link
         self.napp.handle_link_up(mock_interface)
         mock_interface.activate.assert_not_called()
-        assert mock_notify_link_up_if_status.call_count == 1
         mock_notify_topology_update.assert_called()
+        assert self.napp.controller.buffers.app.put.call_count == 2
+        ev = "kytos/topology.notify_link_up_if_status"
+        assert self.napp.controller.buffers.app.put.call_args[0][0].name == ev
 
     @patch('time.sleep')
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')


### PR DESCRIPTION
Closes https://github.com/kytos-ng/mef_eline/issues/503
Closes #158 


### Summary

See updated changelog file 

### Local Tests

- The original bug I didn't manage to reproduce. 
- I found another related adjacent one that seems the cause, and that one no longer reproduces as [mentioned here](https://github.com/kytos-ng/mef_eline/issues/503#issuecomment-2341456265)
- I've also run 2 x hundreds of link flaps and the link status always remained correct and the events were notified as expected

```

def main() -> None:
    """Main function."""
    link_flap_iters = 500
    interfaces = ["s1-eth4"]
    link_id = "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07"
    wait_for = 10
    test_iters = 5

    for test_iter in range(test_iters):
        print(f"link_flap test iteration {test_iter}")
        assert_topology_link_up(link_id)
        for i in range(link_flap_iters):
            do_link_flap(interfaces)
        print(f"\t waiting for {wait_for} secs before next iteration")
        time.sleep(wait_for)
        assert_topology_link_up(link_id)


❯ python flap.py 
link_flap test iteration 0
[sudo] password for viniarck: 
         waiting for 10 secs before next iteration
link_flap test iteration 1
         waiting for 10 secs before next iteration
link_flap test iteration 2
         waiting for 10 secs before next iteration
link_flap test iteration 3
         waiting for 10 secs before next iteration
link_flap test iteration 4
         waiting for 10 secs before next iteration



0:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07) changed status EntityStatus.UP, reason: link up
2024-09-10 13:07:18,992 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_125) Event handle_link_up Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-et
h4', 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
kytos $> 

kytos $> 2024-09-10 13:07:25,993 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57978 - "GET /api/kytos/topology/v3/links/ HTTP/1.1" 200
2024-09-10 13:07:36,178 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44186 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-09-10 13:07:36,190 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, total_length: 
1,  flows[0, 1]: [{'match': {'in_port': 4, 'dl_vlan': 2}, 'cookie': 12253495624854485573, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_e
line', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-09-10 13:07:36,195 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44190 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-09-10 13:07:36,204 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False, total_length: 
1,  flows[0, 1]: [{'match': {'in_port': 3, 'dl_vlan': 2}, 'cookie': 12253495624854485573, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_e
line', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-09-10 13:07:36,208 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44196 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-09-10 13:07:36,213 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) Failover path for EVC(0d295958413a45, evpl2) was deployed.



❯ python flap.py
link_flap test iteration 0
         waiting for 10 secs before next iteration
link_flap test iteration 1
         waiting for 10 secs before next iteration
link_flap test iteration 2
         waiting for 10 secs before next iteration
link_flap test iteration 3
         waiting for 10 secs before next iteration
link_flap test iteration 4
         waiting for 10 secs before next iteration

~/repos/kytos/ master*  1m 40s


2024-09-10 13:10:50,729 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LINK_DOWN
2024-09-10 13:10:50,730 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state 0
2024-09-10 13:10:50,730 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LINK_DOWN
2024-09-10 13:10:50,739 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2024-09-10 13:10:50,739 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2024-09-10 13:10:50,783 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_22) Event handle_interface_link_up Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
2024-09-10 13:10:50,821 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_3) Event handle_interface_link_up Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-09-10 13:10:53,742 - INFO [kytos.napps.kytos/topology] (thread_pool_app_71) Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('00:00:
00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07) changed status EntityStatus.UP, reason: link up
2024-09-10 13:10:53,748 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_181) Event handle_link_up Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-e
th4', 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-09-10 13:11:00,747 - INFO [uvicorn.access] (MainThread) 127.0.0.1:36022 - "GET /api/kytos/topology/v3/links/ HTTP/1.1" 200
```

### End-to-End Tests

With this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 243 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12484.66s (3:28:04) =
```