### PR TITLE
Switch interruptions to use dynamic_single for handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.3] - 2024-09-13
+***********************
+
+Changed
+=======
+- Combined  ``interruption.start`` and ``interruption.end`` handlers to use a single event ``interruption.(start|end)`` handler. The new handler is also uses the ``dynamic_single`` pool when processing events to ensure in order processing.
+
 [2024.1.2] - 2024-09-10
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2024.1.2",
+  "version": "2024.1.3",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -54,8 +54,7 @@ class TestMain:
             '.*.switch.(new|reconnected)',
             '.*.switch.port.created',
             'kytos/topology.notify_link_up_if_status',
-            'topology.interruption.start',
-            'topology.interruption.end',
+            'topology.interruption.(start|end)',
             'kytos/core.interface_tags',
         ]
         assert sorted(expected_events) == sorted(actual_events)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -82,8 +82,7 @@ class TestMain:
             'kytos/.*.liveness.disabled',
             '.*.switch.port.created',
             'kytos/topology.notify_link_up_if_status',
-            'topology.interruption.start',
-            'topology.interruption.end',
+            'topology.interruption.(start|end)',
             'kytos/core.interface_tags',
         ]
         actual_events = self.napp.listeners()


### PR DESCRIPTION
Closes #155

### Summary

Replaces the existing event handlers for interruptions with a single event handler using the dynamic_single pool.

### Local Tests

Interruptions appear to be processed by topology in a similar fashion as before.

### End-to-End Tests

Here are the E2E results:

```
kytos_1        | Starting enhanced syslogd: rsyslogd.
kytos_1        | /etc/openvswitch/conf.db does not exist ... (warning).
kytos_1        | Creating empty database /etc/openvswitch/conf.db.
kytos_1        | Starting ovsdb-server.
kytos_1        | Configuring Open vSwitch system IDs.
kytos_1        | Starting ovs-vswitchd.
kytos_1        | Enabling remote OVSDB managers.
kytos_1        | + '[' -z '' ']'
kytos_1        | + '[' -z '' ']'
kytos_1        | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos_1        | There is no NAPPS_PATH specified. Default will be used.
kytos_1        | + NAPPS_PATH=
kytos_1        | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos_1        | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos_1        | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos_1        | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos_1        | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos_1        | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos_1        | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos_1        | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos_1        | + kytosd --help
kytos_1        | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos_1        | + test -z ''
kytos_1        | + TESTS=tests/
kytos_1        | + test -z ''
kytos_1        | + RERUNS=2
kytos_1        | + python3 scripts/wait_for_mongo.py
kytos_1        | Trying to run hello command on MongoDB...
kytos_1        | Trying to run 'hello' command on MongoDB...
kytos_1        | Trying to run 'hello' command on MongoDB...
kytos_1        | Ran 'hello' command on MongoDB successfully. It's ready!
kytos_1        | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos_1        | ============================= test session starts ==============================
kytos_1        | platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
kytos_1        | rootdir: /tests
kytos_1        | plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
kytos_1        | collected 267 items
kytos_1        | 
kytos_1        | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos_1        | tests/test_e2e_05_topology.py ..................                         [  7%]
kytos_1        | tests/test_e2e_06_topology.py ....                                       [  8%]
kytos_1        | tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
kytos_1        | tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
kytos_1        | tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
kytos_1        | tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
kytos_1        | .                                                                        [ 44%]
kytos_1        | tests/test_e2e_14_mef_eline.py x                                         [ 45%]
kytos_1        | tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
kytos_1        | tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
kytos_1        | tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
kytos_1        | tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
kytos_1        | tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
kytos_1        | tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
kytos_1        | tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
kytos_1        | tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
kytos_1        | tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
kytos_1        | tests/test_e2e_40_sdntrace.py ................                           [ 77%]
kytos_1        | tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
kytos_1        | tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
kytos_1        | tests/test_e2e_50_maintenance.py ............................            [ 92%]
kytos_1        | tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
kytos_1        | tests/test_e2e_70_kytos_stats.py ....R.R...                              [ 97%]
kytos_1        | tests/test_e2e_80_pathfinder.py ss......                                 [100%]
kytos_1        | 
kytos_1        | =============================== warnings summary ===============================
kytos_1        | usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
kytos_1        |   /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '--reruns', '2', '-r', 'fEr']
kytos_1        |     warnings.warn(f"Unknown arguments: {unknown}")
kytos_1        | 
kytos_1        | test_e2e_01_kytos_startup.py: 17 warnings
kytos_1        | test_e2e_05_topology.py: 17 warnings
kytos_1        | test_e2e_06_topology.py: 76 warnings
kytos_1        | test_e2e_10_mef_eline.py: 17 warnings
kytos_1        | test_e2e_11_mef_eline.py: 25 warnings
kytos_1        | test_e2e_12_mef_eline.py: 17 warnings
kytos_1        | test_e2e_13_mef_eline.py: 17 warnings
kytos_1        | test_e2e_14_mef_eline.py: 76 warnings
kytos_1        | test_e2e_15_mef_eline.py: 17 warnings
kytos_1        | test_e2e_16_mef_eline.py: 17 warnings
kytos_1        | test_e2e_20_flow_manager.py: 17 warnings
kytos_1        | test_e2e_21_flow_manager.py: 17 warnings
kytos_1        | test_e2e_22_flow_manager.py: 17 warnings
kytos_1        | test_e2e_23_flow_manager.py: 17 warnings
kytos_1        | test_e2e_30_of_lldp.py: 17 warnings
kytos_1        | test_e2e_31_of_lldp.py: 17 warnings
kytos_1        | test_e2e_32_of_lldp.py: 11 warnings
kytos_1        | test_e2e_40_sdntrace.py: 49 warnings
kytos_1        | test_e2e_41_kytos_auth.py: 17 warnings
kytos_1        | test_e2e_42_sdntrace.py: 84 warnings
kytos_1        | test_e2e_50_maintenance.py: 17 warnings
kytos_1        | test_e2e_60_of_multi_table.py: 17 warnings
kytos_1        | test_e2e_70_kytos_stats.py: 17 warnings
kytos_1        | test_e2e_80_pathfinder.py: 37 warnings
kytos_1        |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos_1        |     return ( StrictVersion( cls.OVSVersion ) <
kytos_1        | 
kytos_1        | test_e2e_01_kytos_startup.py: 17 warnings
kytos_1        | test_e2e_05_topology.py: 17 warnings
kytos_1        | test_e2e_06_topology.py: 76 warnings
kytos_1        | test_e2e_10_mef_eline.py: 17 warnings
kytos_1        | test_e2e_11_mef_eline.py: 25 warnings
kytos_1        | test_e2e_12_mef_eline.py: 17 warnings
kytos_1        | test_e2e_13_mef_eline.py: 17 warnings
kytos_1        | test_e2e_14_mef_eline.py: 76 warnings
kytos_1        | test_e2e_15_mef_eline.py: 17 warnings
kytos_1        | test_e2e_16_mef_eline.py: 17 warnings
kytos_1        | test_e2e_20_flow_manager.py: 17 warnings
kytos_1        | test_e2e_21_flow_manager.py: 17 warnings
kytos_1        | test_e2e_22_flow_manager.py: 17 warnings
kytos_1        | test_e2e_23_flow_manager.py: 17 warnings
kytos_1        | test_e2e_30_of_lldp.py: 17 warnings
kytos_1        | test_e2e_31_of_lldp.py: 17 warnings
kytos_1        | test_e2e_32_of_lldp.py: 11 warnings
kytos_1        | test_e2e_40_sdntrace.py: 49 warnings
kytos_1        | test_e2e_41_kytos_auth.py: 17 warnings
kytos_1        | test_e2e_42_sdntrace.py: 84 warnings
kytos_1        | test_e2e_50_maintenance.py: 17 warnings
kytos_1        | test_e2e_60_of_multi_table.py: 17 warnings
kytos_1        | test_e2e_70_kytos_stats.py: 17 warnings
kytos_1        | test_e2e_80_pathfinder.py: 37 warnings
kytos_1        |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos_1        |     StrictVersion( '1.10' ) )
kytos_1        | 
kytos_1        | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos_1        | ------------------------------- start/stop times -------------------------------
kytos_1        | rerun: 0
kytos_1        | test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_025_packet_count_per_flow: 2024-09-13,17:37:17.818876 - 2024-09-13,17:37:17.823817
kytos_1        | self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7f53d4372f90>
kytos_1        | 
kytos_1        |     def test_025_packet_count_per_flow(self):
kytos_1        |         """Test packet_count_per_flow"""
kytos_1        |         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'
kytos_1        |         response = requests.get(api_url)
kytos_1        |         assert response.status_code == 200, response.text
kytos_1        |         data_flow = response.json()['00:00:00:00:00:00:00:01']
kytos_1        |     
kytos_1        |         api_url = KYTOS_STATS + '/packet_count/per_flow/00:00:00:00:00:00:00:01'
kytos_1        |         response = requests.get(api_url)
kytos_1        |         assert response.status_code == 200, response.text
kytos_1        |         data = response.json()
kytos_1        |         for info_flow in data:
kytos_1        |             flow_id = info_flow['flow_id']
kytos_1        |             count = data_flow[flow_id]['packet_count']
kytos_1        |             assert info_flow['packet_counter'] == count
kytos_1        | >           assert info_flow['packet_per_second'] == count/data_flow[flow_id]['duration_sec']
kytos_1        | E           ZeroDivisionError: division by zero
kytos_1        | 
kytos_1        | tests/test_e2e_70_kytos_stats.py:233: ZeroDivisionError
kytos_1        | rerun: 0
kytos_1        | test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_030_bytes_count_per_flow: 2024-09-13,17:38:01.560107 - 2024-09-13,17:38:01.564703
kytos_1        | self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7f53d4373610>
kytos_1        | 
kytos_1        |     def test_030_bytes_count_per_flow(self):
kytos_1        |         """Test bytes_count_per_flow"""
kytos_1        |     
kytos_1        |         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'
kytos_1        |         response = requests.get(api_url)
kytos_1        |         assert response.status_code == 200, response.text
kytos_1        |         data_flow = response.json()['00:00:00:00:00:00:00:01']
kytos_1        |     
kytos_1        |         api_url = KYTOS_STATS + '/bytes_count/per_flow/00:00:00:00:00:00:00:01'
kytos_1        |         response = requests.get(api_url)
kytos_1        |         assert response.status_code == 200, response.text
kytos_1        |         data = response.json()
kytos_1        |         for info_flow in data:
kytos_1        |             flow_id = info_flow['flow_id']
kytos_1        |             count = data_flow[flow_id]['byte_count']
kytos_1        |             assert info_flow['bytes_counter'] == count
kytos_1        | >           assert info_flow['bits_per_second'] == 8 * count/data_flow[flow_id]['duration_sec']
kytos_1        | E           ZeroDivisionError: division by zero
kytos_1        | 
kytos_1        | tests/test_e2e_70_kytos_stats.py:252: ZeroDivisionError
kytos_1        | =========================== rerun test summary info ============================
kytos_1        | RERUN test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_025_packet_count_per_flow
kytos_1        | RERUN test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_030_bytes_count_per_flow
kytos_1        | = 243 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings, 2 rerun in 10786.50s (2:59:46) =
kytos-tests_kytos_1 exited with code 0
```