### PR TITLE
hotfix 2023.2.1: increased acquired lock scope when handling link up|down

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.1] - 2024-10-04
+
+Fixed
+=====
+- Fixed link down thread safety notification issue
+
+Added
+=====
+- Included link changed status log info for correlation
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2023.2.0",
+  "version": "2023.2.1",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -1228,6 +1228,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 (not link.status_reason and link.status == EntityStatus.UP)
                 and link_id not in self.link_up
             ):
+                log.info(f"{link} changed status {link.status}, "
+                         f"reason: {reason}")
                 self.link_up.add(link_id)
                 event = KytosEvent(
                     name='kytos/topology.link_up',
@@ -1240,6 +1242,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 (link.status_reason or link.status != EntityStatus.UP)
                 and link_id in self.link_up
             ):
+                log.info(f"{link} changed status {link.status}, "
+                         f"reason: {reason}")
                 self.link_up.remove(link_id)
                 event = KytosEvent(
                     name='kytos/topology.link_down',

--- a/main.py
+++ b/main.py
@@ -52,7 +52,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                                      DEFAULT_LINK_UP_TIMER)
 
         self._links_lock = Lock()
-        self._links_notify_lock = defaultdict(Lock)
         # to keep track of potential unorded scheduled interface events
         self._intfs_lock = defaultdict(Lock)
         self._intfs_updated_at = {}
@@ -964,7 +963,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_updated_at[interface.id] = event.timestamp
-        interface.deactivate()
+            interface.deactivate()
         self.handle_interface_link_down(interface, event)
 
     @listen_to('.*.switch.interface.deleted')
@@ -994,7 +993,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_updated_at[interface.id] = event.timestamp
-        self.handle_link_up(interface)
+            self.handle_link_up(interface)
 
     @tenacity.retry(
         stop=stop_after_attempt(3),
@@ -1030,7 +1029,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         time.sleep(self.link_up_timer)
         if link.status != EntityStatus.UP:
             return
-        with self._links_notify_lock[link.id]:
+        with self._links_lock:
             notified_at = link.get_metadata("notified_up_at")
             if (
                 notified_at
@@ -1064,7 +1063,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.extend_metadata(metadata)
             link.activate()
             self.notify_topology_update()
-        self.notify_link_up_if_status(link, "link up")
+            event = KytosEvent(
+                name="kytos/topology.notify_link_up_if_status",
+                content={"reason": "link up", "link": link}
+            )
+            self.controller.buffers.app.put(event)
 
     @listen_to('.*.switch.interface.link_down')
     def on_interface_link_down(self, event):
@@ -1084,7 +1087,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_updated_at[interface.id] = event.timestamp
-        self.handle_link_down(interface)
+            self.handle_link_down(interface)
 
     def handle_link_down(self, interface):
         """Notify a link is down."""


### PR DESCRIPTION
Closes #215 

### Summary

See updated changelog file 

### Local Tests

- Created an inter EVC on Kytos-ng version `2023.2` and using this topology branch, exercised one link down, noticed that notification was as expected, including the log message:

```
2024-10-04 16:17:24,180 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC(e66cc60e6d7849, evpl2) was deployed.
2024-10-04 16:17:24,181 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35806 - "POST /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 201
2024-10-04 16:17:24,186 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35846 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-10-04 16:17:24,195 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False,  flows[0, 2]: [
{'match': {'in_port': 2, 'dl_vlan': 1}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 3}], 'owner': 'mef_eline'
, 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 1},
 {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:17:24,203 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35856 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-10-04 16:17:24,208 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]: [
{'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group
': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:17:24,214 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35858 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-10-04 16:17:24,219 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 1]: [
{'match': {'in_port': 2, 'dl_vlan': 1}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group
': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:17:24,223 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35868 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-10-04 16:17:24,229 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_16) Failover path for EVC(e66cc60e6d7849, evpl2) was deployed.
kytos $>                                                                                                                                                                                  

kytos $> 2024-10-04 16:17:36,241 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53476 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200                                    
2024-10-04 16:17:42,178 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state 0
2024-10-04 16:17:42,178 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LINK_DOWN
2024-10-04 16:17:42,179 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state 0
2024-10-04 16:17:42,179 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LINK_DOWN
2024-10-04 16:17:42,181 - INFO [kytos.napps.kytos/topology] (thread_pool_sb_18) Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('00:00:00:
00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07) changed status EntityStatus.DOWN, reason: link down
2024-10-04 16:17:42,182 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4
', 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-10-04 16:17:42,183 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_12) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]:
 [{'match': {'in_port': 1, 'dl_vlan': 7}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_t
ype': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:17:42,186 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_14) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 1]:
 [{'match': {'in_port': 1, 'dl_vlan': 7}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_t
ype': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:17:42,281 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_23) Event handle_interface_link_down Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-10-04 16:17:42,283 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_18) Event handle_interface_link_down Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
2024-10-04 16:17:42,685 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) EVC(e66cc60e6d7849, evpl2) redeployed with failover due to link down c8b55359990f89a5849813dc348d30e9e1f99
1bad1dcb7f82112bd35429d9b07
2024-10-04 16:17:42,704 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12314649828992579657, 'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie_mask': 18446744073709551615}]
2024-10-04 16:17:42,718 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53526 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-10-04 16:17:42,734 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12314649828992579657, 'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie_mask': 18446744073709551615}]
2024-10-04 16:17:42,746 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53528 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
kytos $>                                                                                                                                                                                  

```

- Link up, failover_path eventually deployed too:

```
kytos $> 2024-10-04 16:18:00,984 - INFO [uvicorn.access] (MainThread) 127.0.0.1:39540 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200                                    
2024-10-04 16:18:10,375 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2024-10-04 16:18:10,376 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2024-10-04 16:18:10,478 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_0) Event handle_interface_link_up Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-10-04 16:18:10,480 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_16) Event handle_interface_link_up Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
2024-10-04 16:18:20,389 - INFO [kytos.napps.kytos/topology] (thread_pool_app_3) Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('00:00:00:
00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07) changed status EntityStatus.UP, reason: link up
2024-10-04 16:18:20,395 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_0) Event handle_link_up Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4'
, 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
kytos $>                                                                                                                                                                                  

kytos $>                                                                                                                                                                                  

kytos $> 2024-10-04 16:18:55,407 - INFO [uvicorn.access] (MainThread) 127.0.0.1:50154 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200                                    
2024-10-04 16:19:05,586 - INFO [uvicorn.access] (MainThread) 127.0.0.1:46236 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
2024-10-04 16:19:06,308 - INFO [uvicorn.access] (MainThread) 127.0.0.1:46236 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
2024-10-04 16:19:23,342 - INFO [uvicorn.access] (MainThread) 127.0.0.1:59578 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-10-04 16:19:23,364 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]: [
{'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group
': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:19:23,372 - INFO [uvicorn.access] (MainThread) 127.0.0.1:59588 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-10-04 16:19:23,381 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 1]: [
{'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12314649828992579657, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group
': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-10-04 16:19:23,389 - INFO [uvicorn.access] (MainThread) 127.0.0.1:59600 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-10-04 16:19:23,394 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) Failover path for EVC(e66cc60e6d7849, evpl2) was deployed.
kytos $>                                                                                                                                                                                  

```

### End-to-End Tests

Not needed when back porting