### PR TITLE
[release][backport 2023.2.3] fix: fixed liveness handler potential out of order exec

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.3] - 2024-10-15
+***********************
+
+Fixed
+=====
+- Fixed liveness handler potential out of order execution issue
+
+
 [2023.2.2] - 2024-10-08
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2023.2.2",
+  "version": "2023.2.3",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -833,14 +833,13 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def get_links_from_interfaces(self, interfaces) -> dict:
         """Get links from interfaces."""
         links_found = {}
-        with self._links_lock:
-            for interface in interfaces:
-                for link in self.links.values():
-                    if any((
-                        interface.id == link.endpoint_a.id,
-                        interface.id == link.endpoint_b.id,
-                    )):
-                        links_found[link.id] = link
+        for interface in interfaces:
+            for link in list(self.links.values()):
+                if any((
+                    interface.id == link.endpoint_a.id,
+                    interface.id == link.endpoint_b.id,
+                )):
+                    links_found[link.id] = link
         return links_found
 
     def handle_link_liveness_disabled(self, interfaces) -> None:

--- a/main.py
+++ b/main.py
@@ -797,35 +797,38 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.controller.buffers.app.put(event)
         return JSONResponse("Operation successful")
 
-    @listen_to("kytos/.*.liveness.(up|down)")
-    def on_link_liveness_status(self, event) -> None:
-        """Handle link liveness up|down status event."""
-        link = Link(event.content["interface_a"], event.content["interface_b"])
-        try:
-            link = self.links[link.id]
-        except KeyError:
-            log.error(f"Link id {link.id} not found, {link}")
-            return
-        liveness_status = event.name.split(".")[-1]
-        self.handle_link_liveness_status(self.links[link.id], liveness_status)
+    @listen_to(
+        "kytos/.*.liveness.(up|down|disabled)",
+        pool="dynamic_single"
+    )
+    def on_link_liveness(self, event) -> None:
+        """Handle link liveness up|down|disabled event."""
+        with self._links_lock:
+            liveness_status = event.name.split(".")[-1]
+            if liveness_status == "disabled":
+                interfaces = event.content["interfaces"]
+                self.handle_link_liveness_disabled(interfaces)
+            elif liveness_status in ("up", "down"):
+                link = Link(event.content["interface_a"],
+                            event.content["interface_b"])
+                try:
+                    link = self.links[link.id]
+                except KeyError:
+                    log.error(f"Link id {link.id} not found, {link}")
+                    return
+                self.handle_link_liveness_status(self.links[link.id],
+                                                 liveness_status)
 
     def handle_link_liveness_status(self, link, liveness_status) -> None:
         """Handle link liveness."""
         metadata = {"liveness_status": liveness_status}
         log.info(f"Link liveness {liveness_status}: {link}")
-        self.topo_controller.add_link_metadata(link.id, metadata)
         link.extend_metadata(metadata)
         self.notify_topology_update()
         if link.status == EntityStatus.UP and liveness_status == "up":
             self.notify_link_status_change(link, reason="liveness_up")
         if link.status == EntityStatus.DOWN and liveness_status == "down":
             self.notify_link_status_change(link, reason="liveness_down")
-
-    @listen_to("kytos/.*.liveness.disabled")
-    def on_link_liveness_disabled(self, event) -> None:
-        """Handle link liveness disabled event."""
-        interfaces = event.content["interfaces"]
-        self.handle_link_liveness_disabled(interfaces)
 
     def get_links_from_interfaces(self, interfaces) -> dict:
         """Get links from interfaces."""
@@ -848,8 +851,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         links = self.get_links_from_interfaces(interfaces)
         for link in links.values():
             link.remove_metadata(key)
-        link_ids = list(links.keys())
-        self.topo_controller.bulk_delete_link_metadata_key(link_ids, key)
         self.notify_topology_update()
         for link in links.values():
             self.notify_link_status_change(link, reason="liveness_disabled")


### PR DESCRIPTION

Backport from https://github.com/kytos-ng/topology/pull/227

- For more information check out the linked PR. 
- Unit tests not backported since they aren't run in the CI, and it's the same change as what's already been tested