### PR TITLE
Backport/handle on interface tags lock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,12 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.4] - 2024-10-29
+********************************
+
 Fixed
 =====
-- Backported fix for performing ``handole_on_interface_tags`` within lock to prevent race condition.
+- Backported fix for performing ``handle_on_interface_tags`` within lock to prevent race condition.
 
 [2023.2.3] - 2024-10-15
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Backported fix for performing ``handole_on_interface_tags`` within lock to prevent race condition.
+
 [2023.2.3] - 2024-10-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2023.2.3",
+  "version": "2023.2.4",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -865,7 +865,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ):
                 return
             self._intfs_tags_updated_at[interface.id] = event.timestamp
-        self.handle_on_interface_tags(interface)
+            self.handle_on_interface_tags(interface)
 
     def handle_on_interface_tags(self, interface):
         """Update interface details"""


### PR DESCRIPTION
Closes #229

### Summary

Backports fix for performing ``handle_on_interface_tags`` within lock to prevent race condition.

### Local Tests

Will need to fully setup dev environment for this version to properly test.

### End-to-End Tests

Will need to setup a dev environment for this to properly test.
