### PR TITLE
fix: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changed
 Fixed
 =====
 - Fixed liveness handler potential out of order execution issue
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
 
 General Information
 ===================

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple
 
 import pymongo
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -30,7 +30,7 @@ from napps.kytos.topology.db.models import (InterfaceDetailDoc, LinkDoc,
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class TopoController:
     """TopoController."""


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/535

### Summary

- See updated changelog file 
- Index creation timeout didn't get ajusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/539 

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/539 