### PR TITLE
release 2024.1.5: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.5] - 2025-03-03
+***********************
+
+Fixed
+=====
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
+
 [2024.1.4] - 2024-10-08
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple
 
 import pymongo
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -30,7 +30,7 @@ from napps.kytos.topology.db.models import (InterfaceDetailDoc, LinkDoc,
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class TopoController:
     """TopoController."""

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2024.1.4",
+  "version": "2024.1.5",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/538

- See updated changelog file 
- Index creation timeout didn't get adjusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/541

### Unit tests

```
coverage: OK ✔ in 41.32 seconds
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /home/viniarck/repos/ky20241/topology/.tox/py311
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished pylint
[isort] Skipped 4 files
:) No issues found.
No linter error found.
  coverage: OK (41.32=setup[29.91]+cmd[11.42] seconds)
  lint: OK (40.12=setup[29.95]+cmd[10.17] seconds)
  congratulations :) (81.48 seconds)
```

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/541 