### PR TITLE
Set default retire_vlans range to [4095, 4095]

### DIFF
--- a/scripts/console/2025.1.0/001_retire_vlans.py
+++ b/scripts/console/2025.1.0/001_retire_vlans.py
@@ -6,7 +6,7 @@ import kytos.core.tag_ranges as range_helpers
 # Change to False so this script makes changes
 DRY_RUN = True
 # Modify with VLAN ranges being retired from use
-RETIRED_VLANS = [[1, 99]]
+RETIRED_VLANS = [[4095, 4095]]
 
 def disable_evc(evc_id):
     import httpx


### PR DESCRIPTION
Closes #246

### Summary

Accidentally had pushed the range I was using for testing. This PR sets it to the intended default range of [4095, 4095]

### Local Tests

Doesn't really change the functionality, just the parameters.

### End-to-End Tests

Not appicable to E2E.