### PR TITLE
Backport/2023/fix/successive link up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- Removed usage of link metadata ``last_status_is_active``, ``last_status_change``, and ``notified_up_at``. Network operators should use the ``000_retire_metadata.py`` to retire these metadata fields from links.
+
+Fixed
+=====
+- Fixed issue with successive link up events during switch connection, causing events to be sent out before the topology is in the expected state.
+
+General Information
+===================
+- Added the script ``000_retire_metadata.py`` to retire metadata fields from switches, interfaces, and links.
+
 [2023.2.4] - 2024-10-29
 ********************************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.5] - 2025-05-14
+***********************
+
 Changed
 =======
 - Removed usage of link metadata ``last_status_is_active``, ``last_status_change``, and ``notified_up_at``. Network operators should use the ``000_retire_metadata.py`` to retire these metadata fields from links.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2023.2.4",
+  "version": "2023.2.5",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -1048,7 +1048,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             self.notify_topology_update()
             self.notify_link_status_change(link, reason)
 
-    def handle_link_up(self, interface):
+    def handle_link_up(self, interface: Interface):
         """Handle link up for an interface."""
         with self._links_lock:
             link = self._get_link_from_interface(interface)
@@ -1059,7 +1059,12 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 link.endpoint_b if link.endpoint_a == interface
                 else link.endpoint_a
             )
-            if other_interface.is_active() is False:
+            if (
+                not other_interface.is_active() or
+                not interface.is_active() or
+                not other_interface.switch.is_active() or
+                not interface.switch.is_active()
+            ):
                 self.notify_topology_update()
                 return
             if (

--- a/main.py
+++ b/main.py
@@ -1011,15 +1011,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise httpx.RequestError(res.text)
         return res.json().get(dpid)
 
-    def link_status_hook_link_up_timer(self, link: Link) -> Optional[EntityStatus]:
+    def link_status_hook_link_up_timer(
+        self,
+        link: Link
+    ) -> Optional[EntityStatus]:
         """Link status hook link up timer."""
         tnow = time.time()
-        if (
-            link.is_active()
-            and link.is_enabled()
-            and link.id in self.link_status_change_cache
-            and tnow - self.link_status_change_cache[link.id]['last_status_change'] < self.link_up_timer
-        ):
+        if link.id not in self.link_status_change_cache:
+            return None
+        link_status_info = self.link_status_change_cache[link.id]
+        tdelta = tnow - link_status_info['last_status_change']
+        if tdelta < self.link_up_timer:
             return EntityStatus.DOWN
         return None
 
@@ -1031,7 +1033,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if link.status != EntityStatus.UP:
             return
         with self._links_lock:
-            status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+            status_change_info = self.link_status_change_cache.setdefault(
+                link.id,
+                {}
+            )
             notified_at = status_change_info.get("notified_up_at")
             if (
                 notified_at
@@ -1061,7 +1066,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 link.id not in self.link_status_change_cache or
                 not link.is_active()
             ):
-                status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+                status_change_info = self.link_status_change_cache.setdefault(
+                    link.id,
+                    {}
+                )
                 status_change_info['last_status_change'] = time.time()
                 status_change_info['last_status_is_active'] = True
                 link.activate()
@@ -1100,7 +1108,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 link.id not in self.link_status_change_cache or
                 link.is_active()
             ):
-                status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+                status_change_info = self.link_status_change_cache.setdefault(
+                    link.id,
+                    {}
+                )
                 status_change_info['last_status_change'] = time.time()
                 status_change_info['last_status_is_active'] = False
                 link.deactivate()
@@ -1140,7 +1151,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_topology_update()
         if not link.is_active():
             return
-        status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+        status_change_info = self.link_status_change_cache.setdefault(
+            link.id,
+            {}
+        )
         status_change_info['last_status_change'] = time.time()
         status_change_info['last_status_is_active'] = True
 

--- a/main.py
+++ b/main.py
@@ -1067,7 +1067,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             ]
             for dependency in link_dependencies:
                 if not dependency.is_active():
-                    log.info(f"{link} dependency {dependency} was not ready.")
+                    log.info(f"{link} dependency {dependency} was not active yet.")
                     return
             event = KytosEvent(
                 name="kytos/topology.notify_link_up_if_status",

--- a/main.py
+++ b/main.py
@@ -62,6 +62,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.topo_controller = self.get_topo_controller()
         Link.register_status_func(f"{self.napp_id}_link_up_timer",
                                   self.link_status_hook_link_up_timer)
+        self.link_status_change_cache = {}
         self.topo_controller.bootstrap_indexes()
         self.load_topology()
 
@@ -1010,19 +1011,19 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise httpx.RequestError(res.text)
         return res.json().get(dpid)
 
-    def link_status_hook_link_up_timer(self, link) -> Optional[EntityStatus]:
+    def link_status_hook_link_up_timer(self, link: Link) -> Optional[EntityStatus]:
         """Link status hook link up timer."""
         tnow = time.time()
         if (
             link.is_active()
             and link.is_enabled()
-            and "last_status_change" in link.metadata
-            and tnow - link.metadata['last_status_change'] < self.link_up_timer
+            and link.id in self.link_status_change_cache
+            and tnow - self.link_status_change_cache[link.id]['last_status_change'] < self.link_up_timer
         ):
             return EntityStatus.DOWN
         return None
 
-    def notify_link_up_if_status(self, link, reason="link up") -> None:
+    def notify_link_up_if_status(self, link: Link, reason="link up") -> None:
         """Tries to notify link up and topology changes based on its status
 
         Currently, it needs to wait up to a timer."""
@@ -1030,15 +1031,15 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if link.status != EntityStatus.UP:
             return
         with self._links_lock:
-            notified_at = link.get_metadata("notified_up_at")
+            status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+            notified_at = status_change_info.get("notified_up_at")
             if (
                 notified_at
                 and (now() - notified_at.replace(tzinfo=timezone.utc)).seconds
                 < self.link_up_timer
             ):
                 return
-            key, notified_at = "notified_up_at", now()
-            link.update_metadata(key, now())
+            status_change_info["notified_up_at"] = now()
             self.notify_topology_update()
             self.notify_link_status_change(link, reason)
 
@@ -1056,12 +1057,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             if other_interface.is_active() is False:
                 self.notify_topology_update()
                 return
-            metadata = {
-                'last_status_change': time.time(),
-                'last_status_is_active': True
-            }
-            link.extend_metadata(metadata)
-            link.activate()
+            if (
+                link.id not in self.link_status_change_cache or
+                not link.is_active()
+            ):
+                status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+                status_change_info['last_status_change'] = time.time()
+                status_change_info['last_status_is_active'] = True
+                link.activate()
             self.notify_topology_update()
             event = KytosEvent(
                 name="kytos/topology.notify_link_up_if_status",
@@ -1093,16 +1096,15 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Notify a link is down."""
         with self._links_lock:
             link = self._get_link_from_interface(interface)
-            if not link or not link.get_metadata("last_status_is_active"):
-                self.notify_topology_update()
-                return
-            link.deactivate()
-            metadata = {
-                "last_status_change": time.time(),
-                "last_status_is_active": False,
-            }
-            link.extend_metadata(metadata)
-            self.notify_link_status_change(link, reason="link down")
+            if link and (
+                link.id not in self.link_status_change_cache or
+                link.is_active()
+            ):
+                status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+                status_change_info['last_status_change'] = time.time()
+                status_change_info['last_status_is_active'] = False
+                link.deactivate()
+                self.notify_link_status_change(link, reason="link down")
             self.notify_topology_update()
 
     @listen_to('.*.interface.is.nni')
@@ -1138,12 +1140,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_topology_update()
         if not link.is_active():
             return
+        status_change_info = self.link_status_change_cache.setdefault(link.id, {})
+        status_change_info['last_status_change'] = time.time()
+        status_change_info['last_status_is_active'] = True
 
-        metadata = {
-            'last_status_change': time.time(),
-            'last_status_is_active': True
-        }
-        link.extend_metadata(metadata)
         self.topo_controller.upsert_link(link.id, link.as_dict())
         self.notify_link_up_if_status(link, "link up")
 
@@ -1222,7 +1222,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             else:
                 self.notify_link_status_change(link, reason)
 
-    def notify_link_status_change(self, link, reason='not given'):
+    def notify_link_status_change(self, link: Link, reason='not given'):
         """Send an event to notify (up/down) from a status change on
          a link."""
         link_id = link.id

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from tenacity import (retry_if_exception_type, stop_after_attempt,
                       wait_combine, wait_fixed, wait_random)
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
-from kytos.core.common import EntityStatus
+from kytos.core.common import EntityStatus, GenericEntity
 from kytos.core.exceptions import (KytosInvalidTagRanges,
                                    KytosLinkCreationError, KytosTagError)
 from kytos.core.helpers import listen_to, load_spec, now, validate_openapi
@@ -60,9 +60,12 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.link_status_lock = Lock()
         self._switch_lock = defaultdict(Lock)
         self.topo_controller = self.get_topo_controller()
+
+        # Track when we last received a link up, that resulted in
+        # activating a deactivated link.
+        self.link_status_change = defaultdict[str, dict](dict)
         Link.register_status_func(f"{self.napp_id}_link_up_timer",
                                   self.link_status_hook_link_up_timer)
-        self.link_status_change_cache = {}
         self.topo_controller.bootstrap_indexes()
         self.load_topology()
 
@@ -157,14 +160,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             link.enable()
         else:
             link.disable()
-
-        # These ones are just runtime active southbound protocol data
-        # It won't be stored in the future, only kept in the runtime.
-        # Also network operators can follow logs to track this state changes
-        for key in (
-            "last_status_is_active", "last_status_change", "notified_up_at"
-        ):
-            link_att["metadata"].pop(key, None)
 
         link.extend_metadata(link_att["metadata"])
         interface_a.update_link(link)
@@ -1017,9 +1012,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     ) -> Optional[EntityStatus]:
         """Link status hook link up timer."""
         tnow = time.time()
-        if link.id not in self.link_status_change_cache:
+        if link.id not in self.link_status_change:
             return None
-        link_status_info = self.link_status_change_cache[link.id]
+        link_status_info = self.link_status_change[link.id]
         tdelta = tnow - link_status_info['last_status_change']
         if tdelta < self.link_up_timer:
             return EntityStatus.DOWN
@@ -1033,10 +1028,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if link.status != EntityStatus.UP:
             return
         with self._links_lock:
-            status_change_info = self.link_status_change_cache.setdefault(
-                link.id,
-                {}
-            )
+            status_change_info = self.link_status_change[link.id]
             notified_at = status_change_info.get("notified_up_at")
             if (
                 notified_at
@@ -1060,24 +1052,23 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 else link.endpoint_a
             )
             if (
-                link.id not in self.link_status_change_cache or
+                link.id not in self.link_status_change or
                 not link.is_active()
             ):
-                status_change_info = self.link_status_change_cache.setdefault(
-                    link.id,
-                    {}
-                )
+                status_change_info = self.link_status_change[link.id]
                 status_change_info['last_status_change'] = time.time()
                 link.activate()
             self.notify_topology_update()
-            if (
-                not other_interface.is_active() or
-                not interface.is_active() or
-                not other_interface.switch.is_active() or
-                not interface.switch.is_active()
-            ):
-                log.info(f"{link} dependencies were not ready.")
-                return
+            link_dependencies: list[GenericEntity] =[
+                other_interface.switch,
+                interface.switch,
+                other_interface,
+                interface,
+            ]
+            for dependency in link_dependencies:
+                if not dependency.is_active():
+                    log.info(f"{link} dependency {dependency} was not ready.")
+                    return
             event = KytosEvent(
                 name="kytos/topology.notify_link_up_if_status",
                 content={"reason": "link up", "link": link}
@@ -1146,10 +1137,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.notify_topology_update()
         if not link.is_active():
             return
-        status_change_info = self.link_status_change_cache.setdefault(
-            link.id,
-            {}
-        )
+        status_change_info = self.link_status_change[link.id]
         status_change_info['last_status_change'] = time.time()
 
         self.topo_controller.upsert_link(link.id, link.as_dict())

--- a/main.py
+++ b/main.py
@@ -1060,14 +1060,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 else link.endpoint_a
             )
             if (
-                not other_interface.is_active() or
-                not interface.is_active() or
-                not other_interface.switch.is_active() or
-                not interface.switch.is_active()
-            ):
-                self.notify_topology_update()
-                return
-            if (
                 link.id not in self.link_status_change_cache or
                 not link.is_active()
             ):
@@ -1076,9 +1068,16 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                     {}
                 )
                 status_change_info['last_status_change'] = time.time()
-                status_change_info['last_status_is_active'] = True
                 link.activate()
             self.notify_topology_update()
+            if (
+                not other_interface.is_active() or
+                not interface.is_active() or
+                not other_interface.switch.is_active() or
+                not interface.switch.is_active()
+            ):
+                log.info(f"{link} dependencies were not ready.")
+                return
             event = KytosEvent(
                 name="kytos/topology.notify_link_up_if_status",
                 content={"reason": "link up", "link": link}
@@ -1109,16 +1108,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Notify a link is down."""
         with self._links_lock:
             link = self._get_link_from_interface(interface)
-            if link and (
-                link.id not in self.link_status_change_cache or
-                link.is_active()
-            ):
-                status_change_info = self.link_status_change_cache.setdefault(
-                    link.id,
-                    {}
-                )
-                status_change_info['last_status_change'] = time.time()
-                status_change_info['last_status_is_active'] = False
+            if link:
                 link.deactivate()
                 self.notify_link_status_change(link, reason="link down")
             self.notify_topology_update()
@@ -1161,7 +1151,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             {}
         )
         status_change_info['last_status_change'] = time.time()
-        status_change_info['last_status_is_active'] = True
 
         self.topo_controller.upsert_link(link.id, link.as_dict())
         self.notify_link_up_if_status(link, "link up")

--- a/scripts/db/2025.2.0/000_retire_metadata.py
+++ b/scripts/db/2025.2.0/000_retire_metadata.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from functools import partial
+import sys
+import os
+
+from kytos.core.db import Mongo
+from pymongo.collection import Collection
+
+def unset_collection_metadata(type: str, collection: Collection, metadata_fields: list[str]) -> None:
+    """Unset switch or link metadata"""
+    print(
+        f"Trying to $unset {type} metadata[{'|'.join(metadata_fields)}]..."
+    )
+    db = mongo.client[mongo.db_name]
+    res = collection.update_many(
+        {},
+        {
+            "$unset": {
+                f"metadata.{field}": 1
+                for field in metadata_fields
+            }
+        },
+    )
+    print(f"Modified {res.modified_count} {type} objects")
+
+def unset_interface_metadata(switches: Collection, metadata_fields: list[str]) -> None:
+    """Unset interface metadata"""
+    print(f"Trying to $unset interface metadata[{'|'.join(metadata_fields)}]...")
+    res = switches.update_many(
+        {},
+        {
+            "$unset": {
+                f"interfaces.$[].metadata.{field}": 1
+                for field in metadata_fields
+            }
+        },
+    )
+    print(f"Modified {res.modified_count} switches objects")
+
+
+
+if __name__ == "__main__":
+    mongo = Mongo()
+    db = mongo.client[mongo.db_name]
+    cmds = {
+        "retire_link_metadata": partial(
+            unset_collection_metadata,
+            "link",
+            db["links"]
+        ),
+        "retire_switch_metadata": partial(
+            unset_collection_metadata,
+            "switch",
+            db["switches"]
+        ),
+        "retire_interface_metadata": partial(
+            unset_interface_metadata,
+            db["switches"]
+        ),
+    }
+    try:
+        cmd = os.environ["CMD"]
+        command = cmds[cmd]
+    except KeyError:
+        print(
+            f"Please set the 'CMD' env var. \nIt has to be one of these: {list(cmds.keys())}"
+        )
+        sys.exit(1)
+    try:
+        retire_metadata = os.environ["RETIRE_METADATA"].split(":")
+    except KeyError:
+        print(
+            "Please set the 'RETIRE_METADATA' env var. \n"
+            "It should be a ':' separated list of metadata variables to retire."
+        )
+        sys.exit(1)
+        
+    command(retire_metadata)
+    

--- a/scripts/db/2025.2.0/README.md
+++ b/scripts/db/2025.2.0/README.md
@@ -1,0 +1,42 @@
+## `topology` scripts for Kytos version 2025.2.0
+
+This folder contains Topology's related scripts:
+
+### <code>$unset metadata</code> from DB switches and links collections
+
+[`000_retire_metadata.py`](./000_retire_metadata.py) is a script to remove metadata from `interfaces`, `links`, and `switches`.
+
+
+#### Pre-requisites
+
+- There's no additional Python libraries dependencies required, other than installing the existing `topology`'s, or if you're running in development locally then installing `requirements/dev.in`
+- Make sure you don't have `kytosd` running with otherwise topology will start writing to MongoDB, and the application could overwrite the data you're trying to insert with this script.
+- Make sure MongoDB replica set is up and running.
+- Export the following MongnoDB variables accordingly in case your running outside of a container
+
+```
+export MONGO_USERNAME=
+export MONGO_PASSWORD=
+export MONGO_DBNAME=napps
+export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
+```
+
+- The following `CMD` commands are available:
+
+```
+retire_link_metadata
+retire_interface_metadata
+retire_switch_metadata
+```
+
+- Use the `RETIRE_METADATA` variable to set the metadata to be retired. This should be a `:` separated list of metadata attributes to be removed.
+
+#### Examples
+
+- Retiring `last_status_is_active`, `last_status_change`, and `notified_up_at` from links:
+
+```
+❯ CMD=retire_link_metadata RETIRE_METADATA=last_status_is_active:last_status_change:notified_up_at ./000_retire_metadata.py
+Trying to $unset link metadata[last_status_is_active|last_status_change|notified_up_at]...
+Modified 18 link objects
+```

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1260,7 +1260,7 @@ class TestMain:
         mock_interface_b.is_active.return_value = True
         mock_link = create_autospec(Link)
         mock_link.get_metadata.return_value = tnow
-        mock_link.is_active.side_effect = [False, True]
+        mock_link.is_active.return_value = False
         mock_link.endpoint_a = mock_interface_a
         mock_link.endpoint_b = mock_interface_b
         mock_link_from_interface.return_value = mock_link
@@ -1268,9 +1268,20 @@ class TestMain:
         event = KytosEvent("kytos.of_core.switch.interface.down")
         self.napp.handle_interface_link_up(mock_interface_a, event)
         mock_notify_topology_update.assert_called()
-        mock_link.extend_metadata.assert_called()
+        assert mock_link.id in self.napp.link_status_change_cache
+        link_status_info = self.napp.link_status_change_cache[mock_link.id]
+        assert link_status_info["last_status_is_active"] is True
         mock_link.activate.assert_called()
         mock_notify_link_up_if_status.assert_called()
+
+        mock_link.is_active.return_value = True
+        orig_change_time = link_status_info["last_status_change"]
+
+        self.napp.handle_interface_link_up(mock_interface_a, event)
+
+        link_status_info = self.napp.link_status_change_cache[mock_link.id]
+        new_change_time = link_status_info["last_status_change"]
+        assert orig_change_time == new_change_time
 
     @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
@@ -1336,7 +1347,9 @@ class TestMain:
         self.napp.handle_link_down(mock_interface)
         mock_interface.deactivate.assert_not_called()
         mock_link.deactivate.assert_called()
-        mock_link.extend_metadata.assert_called()
+        assert mock_link.id in self.napp.link_status_change_cache
+        link_status_info = self.napp.link_status_change_cache[mock_link.id]
+        assert link_status_info["last_status_is_active"] is False
         assert mock_topology_update.call_count == 1
         mock_status_change.assert_called()
 
@@ -1353,6 +1366,9 @@ class TestMain:
         mock_link.is_active.return_value = False
         mock_link_from_interface.return_value = mock_link
         mock_link.get_metadata.return_value = False
+        self.napp.link_status_change_cache[mock_link.id] = {
+            "last_status_is_active": False
+        }
         self.napp.handle_link_down(mock_interface)
         mock_topology_update.assert_called()
         mock_status_change.assert_not_called()
@@ -1428,7 +1444,9 @@ class TestMain:
             "interface_b": mock_intf_b
         }
         self.napp.add_links(mock_event)
-        mock_link.extend_metadata.assert_called()
+        assert mock_link.id in self.napp.link_status_change_cache
+        link_status_info = self.napp.link_status_change_cache[mock_link.id]
+        assert link_status_info["last_status_is_active"] is True
         mock_get_link_or_create.assert_called()
         mock_notify_link_up_if_status.assert_called()
         mock_intf_a.update_link.assert_called()
@@ -1559,13 +1577,20 @@ class TestMain:
         """Test status hook link up timer."""
         last_change = time.time() - self.napp.link_up_timer + 5
         link = MagicMock(metadata={"last_status_change": last_change})
+        self.napp.link_status_change_cache[link.id] = {
+            "last_status_change": last_change,
+            "last_status_is_active": True,
+        }
         link.is_active.return_value = True
         link.is_enabled.return_value = True
         res = self.napp.link_status_hook_link_up_timer(link)
         assert res == EntityStatus.DOWN
 
         last_change = time.time() - self.napp.link_up_timer
-        link.metadata["last_status_change"] = last_change
+        self.napp.link_status_change_cache[link.id] = {
+            "last_status_change": last_change,
+            "last_status_is_active": True,
+        }
         res = self.napp.link_status_hook_link_up_timer(link)
         assert res is None
 
@@ -1581,16 +1606,25 @@ class TestMain:
         """Test notify link up if status."""
 
         link = MagicMock(status=EntityStatus.UP)
-        link.get_metadata.return_value = now()
+        self.napp.link_status_change_cache[link.id] = {
+            "notified_up_at": now(),
+            "last_status_is_active": True,
+        }
         assert not self.napp.notify_link_up_if_status(link, "link up")
         link.update_metadata.assert_not_called()
         mock_notify_topo.assert_not_called()
         mock_notify_link.assert_not_called()
 
         link = MagicMock(status=EntityStatus.UP)
-        link.get_metadata.return_value = now() - timedelta(seconds=60)
+        orig_time = now() - timedelta(seconds=60)
+        self.napp.link_status_change_cache[link.id] = {
+            "notified_up_at": orig_time,
+            "last_status_is_active": True,
+        }
         assert not self.napp.notify_link_up_if_status(link, "link up")
-        link.update_metadata.assert_called()
+        link_status_info = self.napp.link_status_change_cache[link.id]
+        new_time = link_status_info["notified_up_at"]
+        assert new_time != orig_time
         mock_notify_topo.assert_called()
         mock_notify_link.assert_called()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1254,9 +1254,15 @@ class TestMain:
          mock_link_from_interface) = args
 
         tnow = time.time()
+        mock_switch_a = create_autospec(Switch)
+        mock_switch_a.is_active.return_value = True
+        mock_switch_b = create_autospec(Switch)
+        mock_switch_b.is_active.return_value = True
         mock_interface_a = create_autospec(Interface)
+        mock_interface_a.switch = mock_switch_a
         mock_interface_a.is_active.return_value = False
         mock_interface_b = create_autospec(Interface)
+        mock_interface_b.switch = mock_switch_b
         mock_interface_b.is_active.return_value = True
         mock_link = create_autospec(Link)
         mock_link.get_metadata.return_value = tnow
@@ -1268,6 +1274,13 @@ class TestMain:
         event = KytosEvent("kytos.of_core.switch.interface.down")
         self.napp.handle_interface_link_up(mock_interface_a, event)
         mock_notify_topology_update.assert_called()
+        assert mock_link.id not in self.napp.link_status_change_cache
+        mock_link.activate.assert_not_called()
+
+        mock_interface_a.is_active.return_value = True
+        event = KytosEvent("kytos.of_core.switch.interface.down")
+        self.napp.handle_interface_link_up(mock_interface_a, event)
+
         assert mock_link.id in self.napp.link_status_change_cache
         link_status_info = self.napp.link_status_change_cache[mock_link.id]
         assert link_status_info["last_status_is_active"] is True
@@ -1399,7 +1412,11 @@ class TestMain:
          mock_notify_link_up_if_status,
          mock_link_from_interface) = args
 
+        mock_switch_a = create_autospec(Switch)
+        mock_switch_a.is_active.return_value = True
         mock_interface = create_autospec(Interface)
+        mock_interface.switch = mock_switch_a
+        mock_interface.is_active.return_value = True
         mock_link = MagicMock(status=EntityStatus.UP)
         mock_link.is_active.return_value = True
         mock_link_from_interface.return_value = mock_link


### PR DESCRIPTION
Backport of  #253 to topology 2023.2.5

### Summary

Makes it so that the link up handler is more stable when handling successive link ups during a switch reconnect.

### Local Tests

Runs as expected. Link ups are handled correctly regardless of the time between the link up, and the switch reconnect.

### End-to-End Tests

Haven't rerun the E2E tests on this version yet.