### PR TITLE
Moved links to core

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ All notable changes to the ``topology`` project will be documented in this file.
 Changed
 =======
 - Removed usage of link metadata ``last_status_is_active``, ``last_status_change``, and ``notified_up_at``. Network operators should use the ``000_retire_metadata.py`` to retire these metadata fields from links.
+- Moved the dictionary for ``Links`` to controller. Now all the links can be accessed with ``self.controller.links`` from all the NApps.
 
 Fixed
 =====

--- a/main.py
+++ b/main.py
@@ -33,6 +33,9 @@ from .controllers import TopoController
 from .exceptions import RestoreError
 from .models import Topology
 
+from contextlib import ExitStack
+from typing import Iterable
+
 DEFAULT_LINK_UP_TIMER = 10
 
 
@@ -46,12 +49,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def setup(self):
         """Initialize the NApp's links list."""
-        self.links: dict[str, Link] = {}
-        self.intf_available_tags = {}
         self.link_up_timer = getattr(settings, 'LINK_UP_TIMER',
                                      DEFAULT_LINK_UP_TIMER)
 
-        self._links_lock = Lock()
+        self._interruption_lock = Lock()
         # to keep track of potential unorded scheduled interface events
         self._intfs_lock = defaultdict(Lock)
         self._intfs_updated_at = {}
@@ -67,6 +68,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         Link.register_status_func(f"{self.napp_id}_link_up_timer",
                                   self.link_status_hook_link_up_timer)
         self.topo_controller.bootstrap_indexes()
+        self._interruption_lock = Lock()
         self.load_topology()
 
     @staticmethod
@@ -90,20 +92,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(400, "Invalid metadata value: {metadata}")
         return metadata
 
-    def _get_link_or_create(self, endpoint_a, endpoint_b):
-        """Get an existing link or create a new one.
-
-        Returns:
-            Tuple(Link, bool): Link and a boolean whether it has been created.
-        """
-        new_link = Link(endpoint_a, endpoint_b)
-
-        if new_link.id in self.links:
-            return (self.links[new_link.id], False)
-
-        self.links[new_link.id] = new_link
-        return (new_link, True)
-
     def _get_switches_dict(self):
         """Return a dictionary with the known switches."""
         switches = {'switches': {}}
@@ -120,7 +108,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def _get_links_dict(self):
         """Return a dictionary with the known links."""
         return {'links': {link.id: link.as_dict() for link in
-                          self.links.copy().values()}}
+                          self.controller.links.copy().values()}}
 
     def _get_topology_dict(self):
         """Return a dictionary with the known topology."""
@@ -129,14 +117,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def _get_topology(self):
         """Return an object representing the topology."""
-        return Topology(self.controller.switches.copy(), self.links.copy())
-
-    def _get_link_from_interface(self, interface: Interface):
-        """Return the link of the interface, or None if it does not exist."""
-        for link in list(self.links.values()):
-            if interface in (link.endpoint_a, link.endpoint_b):
-                return link
-        return None
+        return Topology(self.controller.switches.copy(), self.controller.links.copy())
 
     def _load_link(self, link_att):
         endpoint_a = link_att['endpoint_a']['id']
@@ -152,19 +133,20 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if not interface_b:
             raise RestoreError(f"{error}, endpoint_b {endpoint_b} not found")
 
-        with self._links_lock:
-            link, _ = self._get_link_or_create(interface_a, interface_b)
+        link, _ = self.controller.get_link_or_create(interface_a, interface_b)
 
-        if link_att['enabled']:
-            link.enable()
-        else:
-            link.disable()
+        with link.link_lock:
+            interface_a.update_link(link)
+            interface_b.update_link(link)
+            interface_a.nni = True
+            interface_b.nni = True
 
-        link.extend_metadata(link_att["metadata"])
-        interface_a.update_link(link)
-        interface_b.update_link(link)
-        interface_a.nni = True
-        interface_b.nni = True
+            if link_att['enabled']:
+                link.enable()
+            else:
+                link.disable()
+
+            link.extend_metadata(link_att["metadata"])
 
     def _load_switch(self, switch_id, switch_att):
         log.info(f'Loading switch dpid: {switch_id}')
@@ -208,8 +190,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
         intf_ids = [v["id"] for v in switch_att.get("interfaces", {}).values()]
         intf_details = self.topo_controller.get_interfaces_details(intf_ids)
-        with self._links_lock:
-            self.load_interfaces_tags_values(switch, intf_details)
+        self.load_interfaces_tags_values(switch, intf_details)
 
     # pylint: disable=attribute-defined-outside-init
     def load_topology(self):
@@ -283,12 +264,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         try:
             switch = self.controller.switches[dpid]
             link_ids = set()
-            for _, interface in switch.interfaces.copy().items():
-                if (interface.link and interface.link.is_enabled()):
-                    link_ids.add(interface.link.id)
-                    interface.link.disable()
-                    self.notify_link_enabled_state(interface.link, "disabled")
-            self.topo_controller.bulk_disable_links(link_ids)
+            with ExitStack() as stack:
+                for _, interface in switch.interfaces.copy().items():
+                    if (interface.link and interface.link.is_enabled()):
+                        stack.enter_context(interface.link.link_lock)
+                        link_ids.add(interface.link.id)
+                        interface.link.disable()
+                        self.notify_link_enabled_state(interface.link, "disabled")
+                self.topo_controller.bulk_disable_links(link_ids)
             self.topo_controller.disable_switch(dpid)
             switch.disable()
         except KeyError:
@@ -322,8 +305,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                         detail = f"Interface {intf_id} vlans are being used."\
                                  " Delete any service using vlans."
                         raise HTTPException(409, detail=detail)
-                with self._links_lock:
-                    for link_id, link in self.links.items():
+                with self.controller.links_lock:
+                    for link_id, link in self.controller.links.copy().items():
                         if (dpid in
                                 (link.endpoint_a.switch.dpid,
                                  link.endpoint_b.switch.dpid)):
@@ -429,14 +412,22 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                 interface = switch.interfaces[interface_number]
                 self.topo_controller.enable_interface(interface.id)
                 interface.enable()
-                self.notify_interface_link_status(interface, "link enabled")
+                if interface.link:
+                    with interface.link.link_lock:
+                        self._notify_interface_link_status(
+                            [interface], "link enabled"
+                        )
             except KeyError:
                 msg = f"Switch {dpid} interface {interface_number} not found"
                 raise HTTPException(404, detail=msg)
         else:
             for interface in switch.interfaces.copy().values():
                 interface.enable()
-                self.notify_interface_link_status(interface, "link enabled")
+                if interface.link:
+                    with interface.link.link_lock:
+                        self._notify_interface_link_status(
+                            [interface], "link enabled"
+                        )
             self.topo_controller.upsert_switch(switch.id, switch.as_dict())
         self.notify_topology_update()
         return JSONResponse("Operation successful")
@@ -453,33 +444,34 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             switch = self.controller.switches[dpid]
         except KeyError:
             raise HTTPException(404, detail="Switch not found")
-
+        
+        interfaces: list[Interface] = []
         if interface_disable_id:
-            interface_number = int(interface_disable_id.split(":")[-1])
-
             try:
-                interface = switch.interfaces[interface_number]
-                self.topo_controller.disable_interface(interface.id)
-                if interface.link and interface.link.is_enabled():
-                    self.topo_controller.disable_link(interface.link.id)
-                    interface.link.disable()
-                    self.notify_link_enabled_state(interface.link, "disabled")
-                interface.disable()
-                self.notify_interface_link_status(interface, "link disabled")
+                interface_number = int(interface_disable_id.split(":")[-1])
+                interfaces = [switch.interfaces[interface_number]]
+                self.topo_controller.disable_interface(interfaces[0].id)
             except KeyError:
                 msg = f"Switch {dpid} interface {interface_number} not found"
                 raise HTTPException(404, detail=msg)
         else:
-            link_ids = set()
-            for interface in switch.interfaces.copy().values():
+            interfaces = switch.interfaces.copy().values()
+
+        link_ids: set[Link] = set()
+        with ExitStack() as stack:
+            for interface in interfaces:
                 if interface.link and interface.link.is_enabled():
+                    stack.enter_context(interface.link.link_lock)
                     link_ids.add(interface.link.id)
                     interface.link.disable()
                     self.notify_link_enabled_state(interface.link, "disabled")
                 interface.disable()
-                self.notify_interface_link_status(interface, "link disabled")
+            self._notify_interface_link_status(interfaces, "link disabled")
             self.topo_controller.bulk_disable_links(link_ids)
+
+        if not interface_disable_id:
             self.topo_controller.upsert_switch(switch.id, switch.as_dict())
+
         self.notify_topology_update()
         return JSONResponse("Operation successful")
 
@@ -658,48 +650,42 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         return JSONResponse(self._get_links_dict())
 
     @rest('v3/links/{link_id}/enable', methods=['POST'])
-    def enable_link(self, request: Request) -> JSONResponse:
+    def enable_link(self, request: Request) -> JSONResponse: 
         """Administratively enable a link in the topology."""
         link_id = request.path_params["link_id"]
-        try:
-            with self._links_lock:
-                link = self.links[link_id]
-                if not link.endpoint_a.is_enabled():
-                    detail = f"{link.endpoint_a.id} needs enabling."
-                    raise HTTPException(409, detail=detail)
-                if not link.endpoint_b.is_enabled():
-                    detail = f"{link.endpoint_b.id} needs enabling."
-                    raise HTTPException(409, detail=detail)
-                if not link.is_enabled():
-                    self.topo_controller.enable_link(link.id)
-                    link.enable()
-                    self.notify_link_enabled_state(link, "enabled")
-        except KeyError:
+        link = self.controller.get_link(link_id)
+        if not link:
             raise HTTPException(404, detail="Link not found")
-        self.notify_link_status_change(
-            self.links[link_id],
-            reason='link enabled'
-        )
+
+        with link.link_lock:
+            if not link.endpoint_a.is_enabled():
+                detail = f"{link.endpoint_a.id} needs enabling."
+                raise HTTPException(409, detail=detail)
+            if not link.endpoint_b.is_enabled():
+                detail = f"{link.endpoint_b.id} needs enabling."
+                raise HTTPException(409, detail=detail)
+            if not link.is_enabled():
+                self.topo_controller.enable_link(link.id)
+                link.enable()
+                self.notify_link_enabled_state(link, "enabled")
+            self.notify_link_status_change(link, reason='link enabled')
         self.notify_topology_update()
         return JSONResponse("Operation successful", status_code=201)
 
     @rest('v3/links/{link_id}/disable', methods=['POST'])
-    def disable_link(self, request: Request) -> JSONResponse:
+    def disable_link(self, request: Request) -> JSONResponse: 
         """Administratively disable a link in the topology."""
         link_id = request.path_params["link_id"]
-        try:
-            with self._links_lock:
-                link = self.links[link_id]
-                if link.is_enabled():
-                    self.topo_controller.disable_link(link.id)
-                    link.disable()
-                    self.notify_link_enabled_state(link, "disabled")
-        except KeyError:
+        link = self.controller.get_link(link_id)
+        if not link:
             raise HTTPException(404, detail="Link not found")
-        self.notify_link_status_change(
-            self.links[link_id],
-            reason='link disabled'
-        )
+
+        with link.link_lock:
+            if link.is_enabled():
+                self.topo_controller.disable_link(link.id)
+                link.disable()
+                self.notify_link_enabled_state(link, "disabled")
+            self.notify_link_status_change(link, reason='link disabled')
         self.notify_topology_update()
         return JSONResponse("Operation successful", status_code=201)
 
@@ -715,8 +701,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def get_link_metadata(self, request: Request) -> JSONResponse:
         """Get metadata from a link."""
         link_id = request.path_params["link_id"]
+        link = self.controller.get_link(link_id)
         try:
-            return JSONResponse({"metadata": self.links[link_id].metadata})
+            return JSONResponse({"metadata": link.metadata})
         except KeyError:
             raise HTTPException(404, detail="Link not found")
 
@@ -725,14 +712,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Add metadata to a link."""
         link_id = request.path_params["link_id"]
         metadata = self._get_metadata(request)
-        try:
-            link = self.links[link_id]
-        except KeyError:
+        link = self.controller.get_link(link_id)
+        if not link:
             raise HTTPException(404, detail="Link not found")
 
-        self.topo_controller.add_link_metadata(link_id, metadata)
-        link.extend_metadata(metadata)
-        self.notify_metadata_changes(link, 'added')
+        with link.link_lock:
+            self.topo_controller.add_link_metadata(link_id, metadata)
+            link.extend_metadata(metadata)
+            self.notify_metadata_changes(link, 'added')
         self.notify_topology_update()
         return JSONResponse("Operation successful", status_code=201)
 
@@ -741,19 +728,18 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Delete metadata from a link."""
         link_id = request.path_params["link_id"]
         key = request.path_params["key"]
-        try:
-            link = self.links[link_id]
-        except KeyError:
+        link = self.controller.get_link(link_id)
+        if not link:
             raise HTTPException(404, detail="Link not found")
 
-        try:
-            _ = link.metadata[key]
-        except KeyError:
-            raise HTTPException(404, detail="Metadata not found")
-
-        self.topo_controller.delete_link_metadata_key(link.id, key)
-        link.remove_metadata(key)
-        self.notify_metadata_changes(link, 'removed')
+        with link.link_lock:
+            try:
+                _ = link.metadata[key]
+            except KeyError:
+                raise HTTPException(404, detail="Metadata not found")
+            self.topo_controller.delete_link_metadata_key(link.id, key)
+            link.remove_metadata(key)
+            self.notify_metadata_changes(link, 'removed')
         self.notify_topology_update()
         return JSONResponse("Operation successful")
 
@@ -763,11 +749,14 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
          It won't work for link with other statuses.
         """
         link_id = request.path_params["link_id"]
-        try:
-            with self._links_lock:
-                link = self.links[link_id]
+        link = self.controller.get_link(link_id)
+        if not link:
+            raise HTTPException(404, detail="Link not found.")
+        with self.controller.links_lock:
+            with link.link_lock:
                 if link.status != EntityStatus.DISABLED:
                     raise HTTPException(409, detail="Link is not disabled.")
+
                 if link.endpoint_a.link and link == link.endpoint_a.link:
                     switch = link.endpoint_a.switch
                     link.endpoint_a.link = None
@@ -783,9 +772,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                         switch.id, switch.as_dict()
                     )
                 self.topo_controller.delete_link(link_id)
-                link = self.links.pop(link_id)
-        except KeyError:
-            raise HTTPException(404, detail="Link not found.")
+                link = self.controller.links.pop(link_id)
         self.notify_topology_update()
         name = 'kytos/topology.link.deleted'
         event = KytosEvent(name=name, content={'link': link})
@@ -824,56 +811,47 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     )
     def on_link_liveness(self, event) -> None:
         """Handle link liveness up|down|disabled event."""
-        with self._links_lock:
-            liveness_status = event.name.split(".")[-1]
-            if liveness_status == "disabled":
-                interfaces = event.content["interfaces"]
-                self.handle_link_liveness_disabled(interfaces)
-            elif liveness_status in ("up", "down"):
-                link = Link(event.content["interface_a"],
-                            event.content["interface_b"])
-                try:
-                    link = self.links[link.id]
-                except KeyError:
-                    log.error(f"Link id {link.id} not found, {link}")
-                    return
-                self.handle_link_liveness_status(self.links[link.id],
-                                                 liveness_status)
+        liveness_status = event.name.split(".")[-1]
+        if liveness_status == "disabled":
+            interfaces = event.content["interfaces"]
+            self.handle_link_liveness_disabled(interfaces)
+        elif liveness_status in ("up", "down"):
+            intf_a:Interface = event.content["interface_a"]
+            intf_b:Interface = event.content["interface_b"]
+            if intf_a.link != intf_b.link:
+                log.error("Link from interfaces "
+                          f"{intf_a}, {intf_b}"
+                          "not found.")
+                return
+            self.handle_link_liveness_status(intf_a.link, liveness_status)
+            
 
-    def handle_link_liveness_status(self, link, liveness_status) -> None:
+    def handle_link_liveness_status(self, link: Link, liveness_status: str) -> None:
         """Handle link liveness."""
-        metadata = {"liveness_status": liveness_status}
-        log.info(f"Link liveness {liveness_status}: {link}")
-        link.extend_metadata(metadata)
-        self.notify_topology_update()
-        if link.status == EntityStatus.UP and liveness_status == "up":
-            self.notify_link_status_change(link, reason="liveness_up")
-        if link.status == EntityStatus.DOWN and liveness_status == "down":
-            self.notify_link_status_change(link, reason="liveness_down")
-
-    def get_links_from_interfaces(self, interfaces) -> dict:
-        """Get links from interfaces."""
-        links_found = {}
-        for interface in interfaces:
-            for link in list(self.links.values()):
-                if any((
-                    interface.id == link.endpoint_a.id,
-                    interface.id == link.endpoint_b.id,
-                )):
-                    links_found[link.id] = link
-        return links_found
+        with link.link_lock:
+            metadata = {"liveness_status": liveness_status}
+            log.info(f"Link liveness {liveness_status}: {link}")
+            link.extend_metadata(metadata)
+            self.notify_topology_update()
+            if link.status == EntityStatus.UP and liveness_status == "up":
+                self.notify_link_status_change(link, reason="liveness_up")
+            if link.status == EntityStatus.DOWN and liveness_status == "down":
+                self.notify_link_status_change(link, reason="liveness_down")
 
     def handle_link_liveness_disabled(self, interfaces) -> None:
         """Handle link liveness disabled."""
         log.info(f"Link liveness disabled interfaces: {interfaces}")
 
         key = "liveness_status"
-        links = self.get_links_from_interfaces(interfaces)
-        for link in links.values():
-            link.remove_metadata(key)
-        self.notify_topology_update()
-        for link in links.values():
-            self.notify_link_status_change(link, reason="liveness_disabled")
+        links = self.controller.get_links_from_interfaces(interfaces)
+
+        with ExitStack() as stack:
+            for link in links:
+                stack.enter_context(link.link_lock)
+                link.remove_metadata(key)
+            self.notify_topology_update()
+            for link in links:
+                self.notify_link_status_change(link, reason="liveness_disabled")
 
     @listen_to("kytos/core.interface_tags")
     def on_interface_tags(self, event):
@@ -1009,7 +987,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if interface.is_enabled() or interface.is_active():
             return "It is enabled or active."
 
-        link = self._get_link_from_interface(interface)
+        link = interface.link
         if link:
             return f"It has a link, {link.id}."
 
@@ -1108,7 +1086,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         time.sleep(self.link_up_timer)
         if link.status != EntityStatus.UP:
             return
-        with self._links_lock:
+        with link.link_lock:
             status_change_info = self.link_status_change[link.id]
             notified_at = status_change_info.get("notified_up_at")
             if (
@@ -1123,11 +1101,11 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def handle_link_up(self, interface: Interface):
         """Handle link up for an interface."""
-        with self._links_lock:
-            link = self._get_link_from_interface(interface)
-            if not link:
-                self.notify_topology_update()
-                return
+        link = interface.link
+        if not link:
+            self.notify_topology_update()
+            return
+        with link.link_lock:
             other_interface = (
                 link.endpoint_b if link.endpoint_a == interface
                 else link.endpoint_a
@@ -1159,7 +1137,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             self.controller.buffers.app.put(event)
 
     @listen_to('.*.switch.interface.link_down')
-    def on_interface_link_down(self, event):
+    def on_interface_link_down(self, event: KytosEvent):
         """Update the topology based on a Port Modify event.
 
         The event notifies that an interface's link was changed to 'down'.
@@ -1167,7 +1145,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         interface = event.content['interface']
         self.handle_interface_link_down(interface, event)
 
-    def handle_interface_link_down(self, interface, event):
+    def handle_interface_link_down(self, interface: Interface, event: KytosEvent):
         """Update the topology based on an interface."""
         with self._intfs_lock[interface.id]:
             if (
@@ -1180,12 +1158,12 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def handle_link_down(self, interface):
         """Notify a link is down."""
-        with self._links_lock:
-            link = self._get_link_from_interface(interface)
-            if link:
+        link = interface.link
+        if link:
+            with link.link_lock:
                 link.deactivate()
                 self.notify_link_status_change(link, reason="link down")
-            self.notify_topology_update()
+        self.notify_topology_update()
 
     @listen_to('.*.interface.is.nni')
     def on_add_links(self, event):
@@ -1194,21 +1172,12 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def add_links(self, event):
         """Update the topology with links related to the NNI interfaces."""
-        interface_a = event.content['interface_a']
-        interface_b = event.content['interface_b']
+        interface_a: Interface = event.content['interface_a']
+        interface_b: Interface = event.content['interface_b']
 
         try:
-            with self._links_lock:
-                link, created = self._get_link_or_create(interface_a,
-                                                         interface_b)
-                interface_a.update_link(link)
-                interface_b.update_link(link)
-
-                link.endpoint_a = interface_a
-                link.endpoint_b = interface_b
-
-                interface_a.nni = True
-                interface_b.nni = True
+            link, created = self.controller.get_link_or_create(interface_a,
+                                                               interface_b)
 
         except KytosLinkCreationError as err:
             log.error(f'Error creating link: {err}.')
@@ -1217,13 +1186,21 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if not created:
             return
 
-        self.notify_topology_update()
-        if not link.is_active():
-            return
-        status_change_info = self.link_status_change[link.id]
-        status_change_info['last_status_change'] = time.time()
+        with link.link_lock:
+            interface_a.update_link(link)
+            interface_b.update_link(link)
+            link.endpoint_a = interface_a
+            link.endpoint_b = interface_b
+            interface_a.nni = True
+            interface_b.nni = True
 
-        self.topo_controller.upsert_link(link.id, link.as_dict())
+            self.notify_topology_update()
+            if not link.is_active():
+                return
+
+            status_change_info = self.link_status_change[link.id]
+            status_change_info['last_status_change'] = time.time()
+            self.topo_controller.upsert_link(link.id, link.as_dict())
         self.notify_link_up_if_status(link, "link up")
 
     @listen_to('.*.of_lldp.network_status.updated')
@@ -1264,8 +1241,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def notify_switch_links_status(self, switch, reason):
         """Send an event to notify the status of a link in a switch"""
-        with self._links_lock:
-            for link in self.links.values():
+        for link in self.controller.links.copy().values():
+            with link.link_lock:
                 if switch in (link.endpoint_a.switch, link.endpoint_b.switch):
                     if reason == "link enabled":
                         name = 'kytos/topology.notify_link_up_if_status'
@@ -1288,18 +1265,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                                                self._get_topology()})
         self.controller.buffers.app.put(event)
 
-    def notify_interface_link_status(self, interface, reason):
-        """Send an event to notify the status of a link from
-        an interface."""
-        link = self._get_link_from_interface(interface)
-        if link:
-            if reason == "link enabled":
-                name = 'kytos/topology.notify_link_up_if_status'
-                content = {'reason': reason, "link": link}
-                event = KytosEvent(name=name, content=content)
-                self.controller.buffers.app.put(event)
-            else:
-                self.notify_link_status_change(link, reason)
+    def _notify_interface_link_status(self, interfaces: Iterable[Interface], reason):
+        """Send an event to notify the status of a link from interfaces."""
+        for interface in interfaces:
+            if interface.link:
+                if reason == "link enabled":
+                    name = 'kytos/topology.notify_link_up_if_status'
+                    content = {'reason': reason, "link": interface.link}
+                    event = KytosEvent(name=name, content=content)
+                    self.controller.buffers.app.put(event)
+                else:
+                    self.notify_link_status_change(interface.link, reason)
 
     def notify_link_status_change(self, link: Link, reason='not given'):
         """Send an event to notify (up/down) from a status change on
@@ -1406,7 +1382,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     )
     def on_interruption(self, event: KytosEvent):
         """Deals with service interruptions."""
-        with self._links_lock:
+        with self._interruption_lock:
             _, _, interrupt_type = event.name.rpartition(".")
             if interrupt_type == "start":
                 self.handle_interruption_start(event)
@@ -1432,7 +1408,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         # for interface_id in interfaces:
         #     pass
         for link_id in links:
-            link = self.links.get(link_id)
+            link = self.controller.get_link(link_id)
             if link is None:
                 log.error(
                     "Invalid link id '%s' for interruption of type '%s;",
@@ -1440,7 +1416,8 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                     interrupt_type
                 )
             else:
-                self.notify_link_status_change(link, interrupt_type)
+                with link.link_lock:
+                    self.notify_link_status_change(link, interrupt_type)
         self.notify_topology_update()
 
     def handle_interruption_end(self, event: KytosEvent):
@@ -1462,7 +1439,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         # for interface_id in interfaces:
         #     pass
         for link_id in links:
-            link = self.links.get(link_id)
+            link = self.controller.get_link(link_id)
             if link is None:
                 log.error(
                     "Invalid link id '%s' for interruption of type '%s;",
@@ -1470,5 +1447,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
                     interrupt_type
                 )
             else:
-                self.notify_link_status_change(link, interrupt_type)
+                with link.link_lock:
+                    self.notify_link_status_change(link, interrupt_type)
         self.notify_topology_update()

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@tech/move_links#egg=kytos[dev]
 -e .

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,3 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@tech/move_links#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@tech/core_links#egg=kytos[dev]
 -e .

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -479,17 +479,6 @@ class TestMain:
         mock_get_link_or_create = self.napp.controller.get_link_or_create
         mock_get_link_or_create.return_value = (mock_link, True)
 
-        # enable link
-        link_attrs['enabled'] = True
-        self.napp.controller.links = {link_id: mock_link}
-        self.napp._load_link(link_attrs)
-        assert mock_link.enable.call_count == 1
-        # disable link
-        link_attrs['enabled'] = False
-        self.napp.controller.links = {link_id: mock_link}
-        self.napp._load_link(link_attrs)
-        assert mock_link.disable.call_count == 1
-
     def test_fail_load_link(self):
         """Test fail load_link."""
         self.napp.controller.get_link_or_create = MagicMock()
@@ -1422,10 +1411,6 @@ class TestMain:
         assert mock_link.id in self.napp.link_status_change
         mock_get_link_or_create.assert_called()
         mock_notify_link_up_if_status.assert_called()
-        mock_intf_a.update_link.assert_called()
-        mock_intf_b.update_link.assert_called()
-        mock_link.endpoint_a = mock_intf_a
-        mock_link.endpoint_b = mock_intf_b
 
     def test_notify_switch_enabled(self):
         """Test notify switch enabled."""


### PR DESCRIPTION
Closes #258 

### Summary

Moved links to core.
Every link has their own lock now instead of relying in a general lock for all of them

### Local Tests
Performed link_flaps, created EVCs, restarted kytos.

### End-to-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 284 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 42%]
tests/test_e2e_14_mef_eline.py ......                                    [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py ...........................            [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 70%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 71%]
tests/test_e2e_31_of_lldp.py ...                                         [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 82%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
Running again