### PR TITLE
Bump version to 2025.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.1] - 2025-05-06
+***********************
+
 Changed
 =======
 - Removed usage of link metadata ``last_status_is_active``, ``last_status_change``, and ``notified_up_at``. Network operators should use the ``000_retire_metadata.py`` to retire these metadata fields from links.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2025.1.0",
+  "version": "2025.1.1",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],


### PR DESCRIPTION
### Summary

Bumps the version number to 2025.1.1, adding in the current features from master into that version. After this PR is accepted, master will be tagged as 2025.1.1.

### Local Tests

Not applicable

### End-to-End Tests

Not applicable
