### PR TITLE
Backport: Log a warning for mismatched links 2025.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.2] - 2025-06-12
+***********************
+
+Added
+=====
+- When a link is added and one of the interfaces already has a link a warning would be log to indicate a mismatched link.
+- When two links shared an interface, the last added link will not be unmatched.
+
 [2025.1.1] - 2025-05-06
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2025.1.1",
+  "version": "2025.1.2",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -66,6 +66,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         self.link_status_change = defaultdict[str, dict](dict)
         Link.register_status_func(f"{self.napp_id}_link_up_timer",
                                   self.link_status_hook_link_up_timer)
+        Link.register_status_reason_func(f"{self.napp_id}_mismatched_reason",
+                                         self.detect_mismatched_link)
+        Link.register_status_func(f"{self.napp_id}_mismatched_status",
+                                  self.link_status_mismatched)
         self.topo_controller.bootstrap_indexes()
         self.load_topology()
 
@@ -98,11 +102,33 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """
         new_link = Link(endpoint_a, endpoint_b)
 
-        if new_link.id in self.links:
+        # If link is an old link but mismatched, then treat it as a new link
+        if (new_link.id in self.links
+                and not self.detect_mismatched_link(new_link)):
             return (self.links[new_link.id], False)
 
-        self.links[new_link.id] = new_link
-        return (new_link, True)
+        # Check if any interface already has a link
+        # This old_link is a leftover link that needs to be removed
+        # The other endpoint of the link is the leftover interface
+        if endpoint_a.link and endpoint_a.link != new_link:
+            old_link = endpoint_a.link
+            leftover_interface = (old_link.endpoint_a
+                                  if old_link.endpoint_a != endpoint_a
+                                  else old_link.endpoint_b)
+            log.warning(f"Leftover mismatched link {endpoint_a.link} "
+                        f"in interface {leftover_interface}")
+
+        if endpoint_b.link and endpoint_b.link != new_link:
+            old_link = endpoint_b.link
+            leftover_interface = (old_link.endpoint_b
+                                  if old_link.endpoint_b != endpoint_b
+                                  else old_link.endpoint_a)
+            log.warning(f"Leftover mismatched link {endpoint_b.link} "
+                        f"in interface {leftover_interface}")
+
+        if new_link.id not in self.links:
+            self.links[new_link.id] = new_link
+        return (self.links[new_link.id], True)
 
     def _get_switches_dict(self):
         """Return a dictionary with the known switches."""
@@ -131,13 +157,6 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         """Return an object representing the topology."""
         return Topology(self.controller.switches.copy(), self.links.copy())
 
-    def _get_link_from_interface(self, interface: Interface):
-        """Return the link of the interface, or None if it does not exist."""
-        for link in list(self.links.values()):
-            if interface in (link.endpoint_a, link.endpoint_b):
-                return link
-        return None
-
     def _load_link(self, link_att):
         endpoint_a = link_att['endpoint_a']['id']
         endpoint_b = link_att['endpoint_b']['id']
@@ -155,16 +174,17 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         with self._links_lock:
             link, _ = self._get_link_or_create(interface_a, interface_b)
 
-        if link_att['enabled']:
-            link.enable()
-        else:
-            link.disable()
+            interface_a.update_link(link)
+            interface_b.update_link(link)
+            interface_a.nni = True
+            interface_b.nni = True
+
+            if link_att['enabled']:
+                link.enable()
+            else:
+                link.disable()
 
         link.extend_metadata(link_att["metadata"])
-        interface_a.update_link(link)
-        interface_b.update_link(link)
-        interface_a.nni = True
-        interface_b.nni = True
 
     def _load_switch(self, switch_id, switch_att):
         log.info(f'Loading switch dpid: {switch_id}')
@@ -1011,9 +1031,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         if interface.is_enabled() or interface.is_active():
             return "It is enabled or active."
 
-        link = self._get_link_from_interface(interface)
-        if link:
-            return f"It has a link, {link.id}."
+        with self._links_lock:
+            link = interface.link
+            if link:
+                return f"It has a link, {link.id}."
 
         flow_id = self.get_flow_id_by_intf(interface)
         if flow_id:
@@ -1103,6 +1124,20 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             return EntityStatus.DOWN
         return None
 
+    @staticmethod
+    def detect_mismatched_link(link: Link) -> frozenset[str]:
+        """Check if a link is mismatched."""
+        if (link.endpoint_a.link and link.endpoint_b
+                and link.endpoint_a.link == link.endpoint_b.link):
+            return frozenset()
+        return frozenset(["mismatched_link"])
+
+    def link_status_mismatched(self, link: Link) -> Optional[EntityStatus]:
+        """Check if a link is mismatched and return a status."""
+        if self.detect_mismatched_link(link):
+            return EntityStatus.DOWN
+        return None
+
     def notify_link_up_if_status(self, link: Link, reason="link up") -> None:
         """Tries to notify link up and topology changes based on its status
 
@@ -1126,7 +1161,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_link_up(self, interface: Interface):
         """Handle link up for an interface."""
         with self._links_lock:
-            link = self._get_link_from_interface(interface)
+            link = interface.link
             if not link:
                 self.notify_topology_update()
                 return
@@ -1183,7 +1218,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def handle_link_down(self, interface):
         """Notify a link is down."""
         with self._links_lock:
-            link = self._get_link_from_interface(interface)
+            link = interface.link
             if link:
                 link.deactivate()
                 self.notify_link_status_change(link, reason="link down")
@@ -1295,15 +1330,16 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
     def notify_interface_link_status(self, interface, reason):
         """Send an event to notify the status of a link from
         an interface."""
-        link = self._get_link_from_interface(interface)
-        if link:
-            if reason == "link enabled":
-                name = 'kytos/topology.notify_link_up_if_status'
-                content = {'reason': reason, "link": link}
-                event = KytosEvent(name=name, content=content)
-                self.controller.buffers.app.put(event)
-            else:
-                self.notify_link_status_change(link, reason)
+        with self._links_lock:
+            link = interface.link
+            if link:
+                if reason == "link enabled":
+                    name = 'kytos/topology.notify_link_up_if_status'
+                    content = {'reason': reason, "link": link}
+                    event = KytosEvent(name=name, content=content)
+                    self.controller.buffers.app.put(event)
+                else:
+                    self.notify_link_status_change(link, reason)
 
     def notify_link_status_change(self, link: Link, reason='not given'):
         """Send an event to notify (up/down) from a status change on

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -92,10 +92,14 @@ class TestMain:
         mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
         mock_interface_b = get_interface_mock('s2-eth1', 1, mock_switch_b)
         mock_interface_a.id = dpid_a
+        mock_interface_a.link = None
         mock_interface_b.id = dpid_b
+        mock_interface_b.link = None
 
         link, created = self.napp._get_link_or_create(mock_interface_a,
                                                       mock_interface_b)
+        mock_interface_a.link = link
+        mock_interface_b.link = link
         assert created
         assert link.endpoint_a.id == dpid_a
         assert link.endpoint_b.id == dpid_b
@@ -104,20 +108,90 @@ class TestMain:
                                                       mock_interface_b)
         assert not created
 
-    def test_get_link_from_interface(self):
-        """Test _get_link_from_interface."""
-        mock_switch_a = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
-        mock_switch_b = get_switch_mock("00:00:00:00:00:00:00:02", 0x04)
+    @patch('napps.kytos.topology.main.log')
+    def test_get_link_or_create_mismatched(self, mock_log):
+        """Test _get_link_or_create with mismatched link."""
+        dpid_a = "00:00:00:00:00:00:00:01"
+        dpid_b = "00:00:00:00:00:00:00:02"
+        mock_switch_a = get_switch_mock(dpid_a, 0x04)
+        mock_switch_b = get_switch_mock(dpid_b, 0x04)
         mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
         mock_interface_b = get_interface_mock('s2-eth1', 1, mock_switch_b)
-        mock_interface_c = get_interface_mock('s2-eth1', 2, mock_switch_b)
-        mock_link = get_link_mock(mock_interface_a, mock_interface_b)
-        self.napp.links = {'0e2b5d7bc858b9f38db11b69': mock_link}
-        response = self.napp._get_link_from_interface(mock_interface_a)
-        assert response == mock_link
+        mock_interface_c = get_interface_mock('s2-eth2', 2, mock_switch_b)
+        mock_interface_a.id = dpid_a + ':1'
+        mock_interface_a.link = None
+        mock_interface_b.id = dpid_b + ':1'
+        mock_interface_b.link = None
+        mock_interface_c.id = dpid_b + ':2'
+        mock_interface_c.link = None
 
-        response = self.napp._get_link_from_interface(mock_interface_c)
-        assert not response
+        link1, created = self.napp._get_link_or_create(mock_interface_a,
+                                                       mock_interface_b)
+        assert created
+        assert link1.endpoint_a.id == mock_interface_a.id
+        assert link1.endpoint_b.id == mock_interface_b.id
+
+        mock_interface_a.link = link1
+        mock_interface_b.link = link1
+
+        link2, created = self.napp._get_link_or_create(mock_interface_a,
+                                                       mock_interface_c)
+        assert created
+        assert mock_log.warning.call_count == 1
+        assert link2.endpoint_a.id == mock_interface_a.id
+        assert link2.endpoint_b.id == mock_interface_c.id
+
+        mock_interface_a.link = link2
+        mock_interface_c.link = link2
+
+        link3, created = self.napp._get_link_or_create(mock_interface_b,
+                                                       mock_interface_c)
+        assert created
+        assert mock_log.warning.call_count == 3
+        assert link3.endpoint_a.id == mock_interface_b.id
+        assert link3.endpoint_b.id == mock_interface_c.id
+
+    def test_get_link_or_create_old_mismatched_link(self):
+        """Test _get_link_or_create with recently added old link
+         which was mismatched.
+         Also testing detect_mismatched_link."""
+        dpid_a = "00:00:00:00:00:00:00:01"
+        dpid_b = "00:00:00:00:00:00:00:02"
+        mock_switch_a = get_switch_mock(dpid_a, 0x04)
+        mock_switch_b = get_switch_mock(dpid_b, 0x04)
+        mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
+        mock_interface_b = get_interface_mock('s2-eth1', 1, mock_switch_b)
+        mock_interface_c = get_interface_mock('s2-eth2', 2, mock_switch_b)
+        mock_interface_a.id = dpid_a + ':1'
+        mock_interface_a.link = None
+        mock_interface_b.id = dpid_b + ':1'
+        mock_interface_b.link = None
+        mock_interface_c.id = dpid_b + ':2'
+        mock_interface_c.link = None
+        link1, _ = self.napp._get_link_or_create(mock_interface_a,
+                                                 mock_interface_b)
+        mock_interface_a.link = link1
+        mock_interface_b.link = link1
+
+        # Create mismatching
+        link2, _ = self.napp._get_link_or_create(mock_interface_a,
+                                                 mock_interface_c)
+        mock_interface_a.link = link2
+        mock_interface_c.link = link2
+
+        assert self.napp.detect_mismatched_link(link1)
+        link1.add_metadata('old_data', 'important_data')
+        assert link1.metadata.get('old_data')
+
+        # Clean link1 mismatch and make link2 mismatched
+        actual_link, _ = self.napp._get_link_or_create(mock_interface_a,
+                                                       mock_interface_b)
+        mock_interface_a.link = actual_link
+        mock_interface_b.link = actual_link
+
+        assert actual_link == link1
+        assert self.napp.detect_mismatched_link(link2)
+        assert not self.napp.detect_mismatched_link(link1)
 
     async def test_get_topology(self):
         """Test get_topology."""
@@ -473,9 +547,11 @@ class TestMain:
         mock_interface_a = get_interface_mock('s1-eth1', 1, mock_switch_a)
         mock_interface_a.id = dpid_a + ':1'
         mock_interface_a.available_tags = [1, 2, 3]
+        mock_interface_a.link = None
         mock_interface_b = get_interface_mock('s2-eth1', 1, mock_switch_b)
         mock_interface_b.id = dpid_b + ':1'
         mock_interface_b.available_tags = [1, 2, 3]
+        mock_interface_b.link = None
         mock_switch_a.interfaces = {1: mock_interface_a}
         mock_switch_b.interfaces = {1: mock_interface_b}
         self.napp.controller.switches[dpid_a] = mock_switch_a
@@ -1238,13 +1314,9 @@ class TestMain:
         self.napp.handle_interface_deleted(mock_event)
         mock_handle_interface_link_down.assert_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
-    def test_interface_link_up(self, *args):
+    def test_interface_link_up(self, mock_notify_topology_update):
         """Test interface link_up."""
-        (mock_notify_topology_update,
-         mock_link_from_interface) = args
-
         self.napp.controller.buffers.app.put = MagicMock()
 
         tnow = time.time()
@@ -1263,8 +1335,9 @@ class TestMain:
         mock_link.is_active.return_value = False
         mock_link.endpoint_a = mock_interface_a
         mock_link.endpoint_b = mock_interface_b
-        mock_link_from_interface.return_value = mock_link
         mock_link.status = EntityStatus.UP
+        mock_interface_a.link = mock_link
+        mock_interface_b.link = mock_link
         event = KytosEvent("kytos.of_core.switch.interface.down")
         self.napp.handle_interface_link_up(mock_interface_a, event)
         mock_notify_topology_update.assert_called()
@@ -1292,18 +1365,16 @@ class TestMain:
         new_change_time = link_status_info["last_status_change"]
         assert orig_change_time == new_change_time
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interface_link_down(self, *args):
         """Test interface link down."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        mock_status_change, mock_topology_update = args
 
         mock_interface = create_autospec(Interface)
         mock_link = create_autospec(Link)
         mock_link.is_active.return_value = True
-        mock_link_from_interface.return_value = mock_link
+        mock_interface.link = mock_link
         event = KytosEvent("kytos.of_core.switch.interface.link_up")
         self.napp.handle_interface_link_down(mock_interface, event)
         mock_topology_update.assert_called()
@@ -1341,70 +1412,58 @@ class TestMain:
         mock_topology_update.assert_not_called()
         mock_status_change.assert_not_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_handle_link_down(self, *args):
         """Test interface link down."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        (mock_status_change, mock_topology_update) = args
 
         mock_interface = create_autospec(Interface)
         mock_link = create_autospec(Link)
         mock_link.is_active.return_value = True
-        mock_link_from_interface.return_value = mock_link
+        mock_interface.link = mock_link
         self.napp.handle_link_down(mock_interface)
         mock_interface.deactivate.assert_not_called()
         mock_link.deactivate.assert_called()
         assert mock_topology_update.call_count == 1
         mock_status_change.assert_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
-    def test_handle_link_down_not_active(self, *args):
+    def test_handle_link_down_not_active(self, args):
         """Test interface link down with link not active."""
-        (
-            mock_topology_update,
-            mock_link_from_interface,
-        ) = args
+        mock_topology_update = args
 
         self.napp.controller.buffers.app.put = MagicMock()
 
         mock_interface = create_autospec(Interface)
         mock_link = create_autospec(Link)
         mock_link.is_active.return_value = False
-        mock_link_from_interface.return_value = mock_link
         mock_link.get_metadata.return_value = False
+        mock_interface.link = mock_link
         self.napp.link_up = set()
         self.napp.link_status_change[mock_link.id] = {}
         self.napp.handle_link_down(mock_interface)
         mock_topology_update.assert_called()
         self.napp.controller.buffers.app.put.assert_not_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_handle_link_down_not_active_last_status(self, *args):
         """Test interface link down with link not active."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface) = args
+        (mock_status_change, mock_topology_update) = args
 
         mock_interface = create_autospec(Interface)
         mock_link = create_autospec(Link)
         mock_link.is_active.return_value = False
-        mock_link_from_interface.return_value = mock_link
         mock_link.get_metadata.return_value = True
+        mock_interface.link = mock_link
         self.napp.handle_link_down(mock_interface)
         mock_topology_update.assert_called()
         mock_status_change.assert_called()
 
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
-    def test_handle_link_up(self, *args):
+    def test_handle_link_up(self, mock_notify_topology_update):
         """Test handle link up."""
-        (mock_notify_topology_update,
-         mock_link_from_interface) = args
-
         mock_switch_a = create_autospec(Switch)
         mock_switch_a.is_active.return_value = True
         mock_interface = create_autospec(Interface)
@@ -1412,7 +1471,7 @@ class TestMain:
         mock_interface.is_active.return_value = True
         mock_link = MagicMock(status=EntityStatus.UP)
         mock_link.is_active.return_value = True
-        mock_link_from_interface.return_value = mock_link
+        mock_interface.link = mock_link
         self.napp.handle_link_up(mock_interface)
         mock_interface.activate.assert_not_called()
         mock_notify_topology_update.assert_called()
@@ -1421,13 +1480,11 @@ class TestMain:
         assert self.napp.controller.buffers.app.put.call_args[0][0].name == ev
 
     @patch('time.sleep')
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_handle_link_up_intf_down(self, *args):
         """Test handle link up but one intf down."""
-        (mock_status_change, mock_topology_update,
-         mock_link_from_interface, _) = args
+        (mock_status_change, mock_topology_update, _) = args
 
         mock_switch = create_autospec(Switch)
         mock_interface = create_autospec(Interface)
@@ -1435,7 +1492,7 @@ class TestMain:
         mock_link = MagicMock()
         mock_link.endpoint_a.is_active.return_value = False
         mock_link.is_active.return_value = False
-        mock_link_from_interface.return_value = mock_link
+        mock_interface.link = mock_link
         self.napp.handle_link_up(mock_interface)
         mock_interface.activate.assert_not_called()
         assert mock_topology_update.call_count == 1
@@ -1660,28 +1717,22 @@ class TestMain:
         assert self.napp.controller.buffers.app.put.call_count == 1
 
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
-    @patch('napps.kytos.topology.main.Main._get_link_from_interface')
-    def test_notify_interface_link_status(self, *args):
+    def test_notify_interface_link_status(self, args):
         """Test interface links notification when enable"""
-        (mock_get_link_from_interface,
-         mock_notify_link_status_change) = args
+        mock_notify_link_status_change = args
         buffers_app_mock = MagicMock()
         self.napp.controller.buffers.app = buffers_app_mock
-        mock_link = MagicMock()
-        mock_get_link_from_interface.return_value = mock_link
-        self.napp.notify_interface_link_status(MagicMock(), "link enabled")
-        assert mock_get_link_from_interface.call_count == 1
+        mock_intf = MagicMock(link=MagicMock())
+        self.napp.notify_interface_link_status(mock_intf, "link enabled")
         assert self.napp.controller.buffers.app.put.call_count == 1
 
-        self.napp.notify_interface_link_status(MagicMock(), "link disabled")
-        assert mock_get_link_from_interface.call_count == 2
+        self.napp.notify_interface_link_status(mock_intf, "link disabled")
         assert mock_notify_link_status_change.call_count == 1
         assert self.napp.controller.buffers.app.put.call_count == 1
 
         # Without notification
-        mock_get_link_from_interface.return_value = None
-        self.napp.notify_interface_link_status(MagicMock(), "link enabled")
-        assert mock_get_link_from_interface.call_count == 3
+        mock_intf.link = None
+        self.napp.notify_interface_link_status(mock_intf, "link enabled")
         assert self.napp.controller.buffers.app.put.call_count == 1
 
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
@@ -2163,11 +2214,11 @@ class TestMain:
         assert actual_usage == "It is enabled or active."
 
         mock_intf.is_active.return_value = False
-        self.napp._get_link_from_interface = MagicMock(return_value=Mock())
+        mock_intf.link = Mock()
         actual_usage = self.napp.get_intf_usage(mock_intf)
         assert "It has a link," in actual_usage
 
-        self.napp._get_link_from_interface.return_value = None
+        mock_intf.link = None
         self.napp.get_flow_id_by_intf = MagicMock(return_value="mock_flow")
         actual_usage = self.napp.get_intf_usage(mock_intf)
         assert "There is a flow installed" in actual_usage
@@ -2239,3 +2290,32 @@ class TestMain:
         assert self.napp.topo_controller.upsert_switch.call_count == 1
         delete = self.napp.topo_controller.delete_interface_from_details
         assert delete.call_count == 1
+
+    def test_detect_mismatched_link(self):
+        """Test detect_mismatched_link"""
+        mock_link_1 = MagicMock(id='link_1')
+        mock_link_1.endpoint_a = MagicMock(link=mock_link_1)
+        mock_link_1.endpoint_b = MagicMock(link=None)
+        assert self.napp.detect_mismatched_link(mock_link_1)
+
+        mock_link_1.endpoint_a.link = None
+        mock_link_1.endpoint_b.link = mock_link_1
+        assert self.napp.detect_mismatched_link(mock_link_1)
+
+        mock_link_2 = MagicMock(id='link_2')
+        mock_link_1.endpoint_a.link = mock_link_2
+        assert self.napp.detect_mismatched_link(mock_link_1)
+
+        mock_link_1.endpoint_a.link = mock_link_1
+        assert not self.napp.detect_mismatched_link(mock_link_1)
+
+    @patch('napps.kytos.topology.main.Main.detect_mismatched_link')
+    def test_link_status_mismatched(self, mock_detect_mismatched_link):
+        """Test link_status_mismatched"""
+        mock_link_1 = MagicMock()
+        mock_detect_mismatched_link.return_value = True
+        assert (self.napp.link_status_mismatched(mock_link_1)
+                == EntityStatus.DOWN)
+
+        mock_detect_mismatched_link.return_value = False
+        assert self.napp.link_status_mismatched(mock_link_1) is None


### PR DESCRIPTION
Closes #266

### Summary

- Mismatched links are treated as new links
- Added warning for mismatched links

### Local Tests
Deploy 2 topologies with overlapping links.

### End-to-End Tests
N/A
