### PR TITLE
Fixed the Timeseries Chart/Interface Utilization Graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Added
 - When a link is added and one of the interfaces already has a link a warning would be log to indicate a mismatched link.
 - When two links shared an interface, the last added link will not be unmatched.
 
+Fixed
+=====
+- Fixed the ``k-chart-timeseries``/Interface Statistics Graph.
+
 [2025.1.1] - 2025-05-06
 ***********************
 

--- a/ui/k-info-panel/switch_info.kytos
+++ b/ui/k-info-panel/switch_info.kytos
@@ -74,7 +74,7 @@
         </div>
       </k-accordion-item>
       <k-accordion-item :defaultState="false" title="Interfaces" v-if="this.interfaces">
-         <k-interface :interface_id="k_interface.id" :name="k_interface.name" :port_number="k_interface.port_number" :mac="k_interface.mac" 
+         <k-interface :interface_id="k_interface.id" :interface_switch="k_interface.switch" :name="k_interface.name" :port_number="k_interface.port_number" :mac="k_interface.mac" 
                       :speed="k_interface.speed" :key="k_interface.name" :enabled="k_interface.enabled" :metadata="k_interface.metadata"
                       :active="k_interface.active" :lldp="k_interface.lldp" :nni="k_interface.nni" :uni="k_interface.uni" :content_switch="content_switch" v-for="k_interface in this.interfaces">
          </k-interface>
@@ -366,6 +366,7 @@ module.exports = {
    },
    mounted () {
      this.update_switch_content()
+
    },
    watch: {
      content: {


### PR DESCRIPTION
Closes #274

### Summary

The Interface Utilization Graph is fixed.

<img width="543" height="550" alt="image" src="https://github.com/user-attachments/assets/57d0d3f7-f1d8-4f9f-849c-15bcd9aef3d4" />

### Local Tests

The Graphs displayed properly and no errors were thrown.

### Related PR
