### PR TITLE
[release 2025.1.3] feat: published 'kytos/topology.interface.deleted' on interface deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.3] - 2025-07-22
+***********************
+
+Added
+=====
+
+- Published kytos/topology.interface.deleted event on interface deletion
+
 [2025.1.2] - 2025-06-12
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,18 @@ Content:
     'switch': <switch object>
   }
 
+kytos/topology.interface.deleted
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting that an interface was deleted. It contains the interface instance.
+
+Content:
+
+.. code-block:: python3
+  {
+    'interface': <interface object>
+  }
+
 kytos/topology.link.(enabled|disabled)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2025.1.2",
+  "version": "2025.1.3",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],

--- a/main.py
+++ b/main.py
@@ -838,6 +838,9 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
             raise HTTPException(409, detail=f"Interface could not be "
                                             f"deleted. Reason: {usage}")
         self._delete_interface(interface)
+        name = "kytos/topology.interface.deleted"
+        event = KytosEvent(name=name, content={"interface": interface})
+        self.controller.buffers.app.put(event)
         return JSONResponse("Operation Successful", status_code=200)
 
     @listen_to(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2201,6 +2201,11 @@ class TestMain:
         mock_delete.return_value = True
         response = await self.api_client.delete(endpoint)
         assert response.status_code == 200, response
+        assert self.napp.controller.buffers.app.put.call_count
+        args = self.napp.controller.buffers.app.put.call_args_list
+        event = args[-1][0][0]
+        assert event.name == "kytos/topology.interface.deleted"
+        assert "interface" in event.content
 
     def test_get_intf_usage(self):
         """Test get_intf_usage"""


### PR DESCRIPTION
Closes #277 

### Summary

- See updated changelog file 
- Backport of #278 

### Local Tests

Done on https://github.com/kytos-ng/of_lldp/pull/121

### End-to-End Tests

Done on https://github.com/kytos-ng/of_lldp/pull/121
