### PR TITLE
Added event for interface status changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
 - Published kytos/topology.interface.deleted event on interface deletion.
 - Added node name as subtitle in ``Switch Details`` InfoPanel.
 - Added node names from ``endpoint_a`` and ``endpoint_b`` to ``Link Details`` InfoPanel.
+- Added a new event ``kytos/topology.interface.(enabled|disabled)`` which is published when an interface is disabled or enabled.
 
 [2025.1.1] - 2025-05-06
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 - Published kytos/topology.interface.deleted event on interface deletion.
 - Added node name as subtitle in ``Switch Details`` InfoPanel.
 - Added node names from ``endpoint_a`` and ``endpoint_b`` to ``Link Details`` InfoPanel.
-- Added a new event ``kytos/topology.interface.(enabled|UP|disabled|DOWN)`` which is published when an interface is disabled or enabled.
+- Added a new event ``kytos/topology.interface.(enabled|UP|disabled|DOWN)`` which is published when an interface is disabled or enabled or UP or DOWN (due to maintenance).
 
 [2025.1.1] - 2025-05-06
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 - Published kytos/topology.interface.deleted event on interface deletion.
 - Added node name as subtitle in ``Switch Details`` InfoPanel.
 - Added node names from ``endpoint_a`` and ``endpoint_b`` to ``Link Details`` InfoPanel.
-- Added a new event ``kytos/topology.interface.(enabled|disabled)`` which is published when an interface is disabled or enabled.
+- Added a new event ``kytos/topology.interface.(enabled|UP|disabled|DOWN)`` which is published when an interface is disabled or enabled.
 
 [2025.1.1] - 2025-05-06
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 - Published kytos/topology.interface.deleted event on interface deletion.
 - Added node name as subtitle in ``Switch Details`` InfoPanel.
 - Added node names from ``endpoint_a`` and ``endpoint_b`` to ``Link Details`` InfoPanel.
-- Added a new event ``kytos/topology.interface.(enabled|UP|disabled|DOWN)`` which is published when an interface is disabled or enabled or UP or DOWN (due to maintenance).
+- Added a new event ``kytos/topology.interface.(enabled|up|disabled|down)`` which is published when an interface is disabled or enabled or UP or DOWN (due to maintenance).
 
 [2025.1.1] - 2025-05-06
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -251,7 +251,7 @@ Content:
     'link': <Link object>
   }
 
-kytos/topology.interface.(enabled|disabled)
+kytos/topology.interface.(enabled|UP|disabled|DOWN)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Event reporting that an interface status has changed to enabled or disabled.
 

--- a/README.rst
+++ b/README.rst
@@ -169,24 +169,6 @@ Content:
      'metadata': object's metadata dict
    }
 
-
-.. |License| image:: https://img.shields.io/github/license/kytos-ng/kytos.svg
-   :target: https://github.com/kytos-ng/topology/blob/master/LICENSE
-.. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/topology/badges/build.png?b=master
-  :alt: Build status
-  :target: https://scrutinizer-ci.com/g/kytos-ng/topology/?branch=master
-.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos-ng/topology/badges/coverage.png?b=master
-  :alt: Code coverage
-  :target: https://scrutinizer-ci.com/g/kytos-ng/topology/?branch=master
-.. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/topology/badges/quality-score.png?b=master
-  :alt: Code-quality score
-  :target: https://scrutinizer-ci.com/g/kytos-ng/topology/?branch=master
-.. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg
-   :target: https://github.com/kytos-ng/topology
-.. |Tag| image:: https://img.shields.io/github/tag/kytos-ng/topology.svg
-   :target: https://github.com/kytos-ng/topology/tags
-
-
 kytos/topology.notify_link_up_if_status
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -251,7 +233,7 @@ Content:
     'link': <Link object>
   }
 
-kytos/topology.interface.(enabled|UP|disabled|DOWN)
+kytos/topology.interface.(enabled|up|disabled|down)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Event reporting that an interface status has changed to enabled or disabled.
 
@@ -259,5 +241,22 @@ Content:
 
 .. code-block:: python3
   {
+    'reason': <reason string>,
     'interface': <interface object>
   }
+
+.. |License| image:: https://img.shields.io/github/license/kytos-ng/kytos.svg
+   :target: https://github.com/kytos-ng/topology/blob/master/LICENSE
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/topology/badges/build.png?b=master
+  :alt: Build status
+  :target: https://scrutinizer-ci.com/g/kytos-ng/topology/?branch=master
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos-ng/topology/badges/coverage.png?b=master
+  :alt: Code coverage
+  :target: https://scrutinizer-ci.com/g/kytos-ng/topology/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/topology/badges/quality-score.png?b=master
+  :alt: Code-quality score
+  :target: https://scrutinizer-ci.com/g/kytos-ng/topology/?branch=master
+.. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg
+   :target: https://github.com/kytos-ng/topology
+.. |Tag| image:: https://img.shields.io/github/tag/kytos-ng/topology.svg
+   :target: https://github.com/kytos-ng/topology/tags

--- a/README.rst
+++ b/README.rst
@@ -240,7 +240,7 @@ Content:
   }
 
 kytos/topology.link.(enabled|disabled)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Event reporting that a link status has changed to enabled or disabled.
 
@@ -248,5 +248,16 @@ Content:
 
 .. code-block:: python3
   {
-    'link': <switch object>
+    'link': <Link object>
+  }
+
+kytos/topology.interface.(enabled|disabled)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Event reporting that an interface status has changed to enabled or disabled.
+
+Content:
+
+.. code-block:: python3
+  {
+    'interface': <interface object>
   }

--- a/main.py
+++ b/main.py
@@ -1432,8 +1432,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         )
         # for switch_id in switches:
         #     pass
-        # for interface_id in interfaces:
-        #     pass
+        for interface_id in interfaces:
+            interface = self.controller.get_interface_by_id(interface_id)
+            if interface:
+                self.notify_interface_status(interface, 'DOWN')
         for link_id in links:
             link = self.controller.get_link(link_id)
             if link is None:
@@ -1463,8 +1465,10 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         )
         # for switch_id in switches:
         #     pass
-        # for interface_id in interfaces:
-        #     pass
+        for interface_id in interfaces:
+            interface = self.controller.get_interface_by_id(interface_id)
+            if interface:
+                self.notify_interface_status(interface, 'UP')
         for link_id in links:
             link = self.controller.get_link(link_id)
             if link is None:

--- a/main.py
+++ b/main.py
@@ -1444,7 +1444,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         for interface_id in interfaces:
             interface = self.controller.get_interface_by_id(interface_id)
             if interface:
-                self.notify_interface_status(interface, 'down', 'maintenance')
+                self.notify_interface_status(interface, 'down', interrupt_type)
         for link_id in links:
             link = self.controller.get_link(link_id)
             if link is None:
@@ -1477,7 +1477,7 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         for interface_id in interfaces:
             interface = self.controller.get_interface_by_id(interface_id)
             if interface:
-                self.notify_interface_status(interface, 'up', 'maintenance')
+                self.notify_interface_status(interface, 'up', interrupt_type)
         for link_id in links:
             link = self.controller.get_link(link_id)
             if link is None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2212,11 +2212,11 @@ class TestMain:
         self.napp.controller.buffers.app.put = mock_buffers_put
         intf_mock = Mock()
         expected_name = "kytos/topology.interface.disabled"
-        self.napp.notify_interface_status(intf_mock, 'disabled')
+        self.napp.notify_interface_status(intf_mock, 'disabled', 'test')
         assert mock_buffers_put.call_count == 1
         assert mock_buffers_put.call_args_list[0][0][0].name == expected_name
 
         expected_name = "kytos/topology.interface.enabled"
-        self.napp.notify_interface_status(intf_mock, 'enabled')
+        self.napp.notify_interface_status(intf_mock, 'up', 'test')
         assert mock_buffers_put.call_count == 2
         assert mock_buffers_put.call_args_list[1][0][0].name == expected_name

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2216,7 +2216,7 @@ class TestMain:
         assert mock_buffers_put.call_count == 1
         assert mock_buffers_put.call_args_list[0][0][0].name == expected_name
 
-        expected_name = "kytos/topology.interface.enabled"
+        expected_name = "kytos/topology.interface.up"
         self.napp.notify_interface_status(intf_mock, 'up', 'test')
         assert mock_buffers_put.call_count == 2
         assert mock_buffers_put.call_args_list[1][0][0].name == expected_name

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1602,12 +1602,14 @@ class TestMain:
         self.napp.notify_switch_links_status(mock_switch, "link enabled")
         assert self.napp.controller.buffers.app.put.call_count == 1
 
+    @patch('napps.kytos.topology.main.Main.notify_interface_status')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interruption_start(
         self,
         mock_notify_link_status_change,
-        mock_notify_topology_update
+        mock_notify_topology_update,
+        mock_notify_interface_status,
     ):
         """Tests processing of received interruption start events."""
         link_a = MagicMock()
@@ -1618,6 +1620,8 @@ class TestMain:
             'link_b': link_b,
             'link_c': link_c,
         }
+        mock_get_interface = MagicMock(side_effect=[Mock(), Mock()])
+        self.napp.controller.get_interface_by_id = mock_get_interface
         event = KytosEvent(
             "topology.interruption.start",
             {
@@ -1625,6 +1629,8 @@ class TestMain:
                 'switches': [
                 ],
                 'interfaces': [
+                    'intf_a',
+                    'intf_b',
                 ],
                 'links': [
                     'link_a',
@@ -1641,13 +1647,16 @@ class TestMain:
         )
         assert mock_notify_link_status_change.call_count == 2
         mock_notify_topology_update.assert_called_once()
+        assert mock_notify_interface_status.call_count == 2
 
+    @patch('napps.kytos.topology.main.Main.notify_interface_status')
     @patch('napps.kytos.topology.main.Main.notify_topology_update')
     @patch('napps.kytos.topology.main.Main.notify_link_status_change')
     def test_interruption_end(
         self,
         mock_notify_link_status_change,
-        mock_notify_topology_update
+        mock_notify_topology_update,
+        mock_notify_interface_status,
     ):
         """Tests processing of received interruption end events."""
         link_a = MagicMock()
@@ -1658,6 +1667,8 @@ class TestMain:
             'link_b': link_b,
             'link_c': link_c,
         }
+        mock_get_interface = MagicMock(side_effect=[Mock(), Mock()])
+        self.napp.controller.get_interface_by_id = mock_get_interface
         event = KytosEvent(
             "topology.interruption.start",
             {
@@ -1665,6 +1676,8 @@ class TestMain:
                 'switches': [
                 ],
                 'interfaces': [
+                    'intf_a',
+                    'intf_b',
                 ],
                 'links': [
                     'link_a',
@@ -1681,6 +1694,7 @@ class TestMain:
         )
         assert mock_notify_link_status_change.call_count == 2
         mock_notify_topology_update.assert_called_once()
+        assert mock_notify_interface_status.call_count == 2
 
     async def test_set_tag_range(self):
         """Test set_tag_range"""


### PR DESCRIPTION
Closes #285

### Summary

Added new event to notify interface sta

### Local Tests
Exercise `mef_eline` [PR](https://github.com/kytos-ng/mef_eline/compare/master...kytos-ng:mef_eline:feat/interface_status_event?expand=1)

### End-to-End Tests
Running all tests plus the ones from this [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/392)
