### PR TITLE
release: bumped 2025.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.0] - 2026-02-02
+***********************
+
 Changed
 =======
 - Moved the dictionary for ``Links`` to controller. Now all the links can be accessed with ``self.controller.links`` from all the NApps.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "topology",
   "description": "Manage the network topology.",
-  "version": "2025.1.1",
+  "version": "2025.2.0",
   "napp_dependencies": ["kytos/of_core", "kytos/of_lldp"],
   "license": "MIT",
   "tags": ["topology", "rest"],


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/603

### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A (nightly tests passing)
