### PR TITLE
Updating switch when interface is created

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ All notable changes to the ``topology`` project will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Fixed updating switch interfaces in the database when an interface is added while Kytos is running (from ``OFPPR_ADD`` message).
+
 Changed
 =======
 - Removed unused ``link_side`` from the DB switches collection.

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Subscribed
 - ``.*.switch.(new|reconnected)``
 - ``.*.connection.lost``
 - ``.*.switch.interface.created``
+- ``.*.switch.interfaces.created``
 - ``.*.switch.interface.deleted``
 - ``.*.switch.interface.link_up``
 - ``.*.switch.interface.link_down``

--- a/main.py
+++ b/main.py
@@ -933,12 +933,13 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
 
     def handle_interface_created(self, event):
         """Update the topology based on an interface created event.
-
         It's handled as a link_up in case a switch send a
         created event again and it can be belong to a link.
+        Updates the switch in the DB when the event has come  from
+        of_core only.
         """
         interface = event.content['interface']
-        if "of_core" in event.name:
+        if "kytos/of_core.switch.interface.created" in event.name:
             switch = interface.switch
             self.topo_controller.upsert_switch(switch.id, switch.as_dict())
         if not interface.is_active():

--- a/main.py
+++ b/main.py
@@ -938,12 +938,15 @@ class Main(KytosNApp):  # pylint: disable=too-many-public-methods
         created event again and it can be belong to a link.
         """
         interface = event.content['interface']
+        if "of_core" in event.name:
+            switch = interface.switch
+            self.topo_controller.upsert_switch(switch.id, switch.as_dict())
         if not interface.is_active():
             self.handle_interface_link_down(interface, event)
         else:
             self.handle_interface_link_up(interface, event)
 
-    @listen_to('.*.topology.switch.interface.created')
+    @listen_to('.*.switch.interface.created')
     def on_interface_created(self, event):
         """Handle individual interface create event.
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -46,7 +46,7 @@ class TestMain:
             '.*.interface.is.nni',
             '.*.connection.lost',
             '.*.switch.interfaces.created',
-            '.*.topology.switch.interface.created',
+            '.*.switch.interface.created',
             '.*.switch.interface.deleted',
             '.*.switch.interface.link_down',
             '.*.switch.interface.link_up',

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -69,7 +69,7 @@ class TestMain:
             '.*.interface.is.nni',
             '.*.connection.lost',
             '.*.switch.interfaces.created',
-            '.*.topology.switch.interface.created',
+            '.*.switch.interface.created',
             '.*.switch.interface.deleted',
             '.*.switch.interface.link_down',
             '.*.switch.interface.link_up',
@@ -1164,12 +1164,24 @@ class TestMain:
     def test_handle_interface_created(self, mock_link_up, mock_link_down):
         """Test handle_interface_created."""
         mock_event = MagicMock()
+        upsert_mock = self.napp.topo_controller.upsert_switch
+        mock_switch = create_autospec(Switch)
         mock_interface = create_autospec(Interface)
+        mock_interface.switch = mock_switch
         mock_interface.id = "1"
         mock_event.content = {'interface': mock_interface}
+        mock_event.name = "kytos/topology.switch.interface.created"
         self.napp.handle_interface_created(mock_event)
         mock_link_up.assert_called()
         mock_link_down.assert_not_called()
+        upsert_mock.assert_not_called()
+
+        # Event from of_core
+        mock_event.name = "kytos/of_core.switch.interface.created"
+        self.napp.handle_interface_created(mock_event)
+        mock_link_up.assert_called()
+        mock_link_down.assert_not_called()
+        upsert_mock.assert_called_with(mock_switch.id, mock_switch.as_dict())
 
     @patch('napps.kytos.topology.main.Main.handle_interface_link_down')
     @patch('napps.kytos.topology.main.Main.handle_interface_link_up')


### PR DESCRIPTION
Closes #290

### Summary

Fixed updating switch interfaces in the database when an interface is added while Kytos is running.
Only added updated after `OFPPR_ADD` which comes only from `of_core` 

### Local Tests
Created new interface on Mininet with this commands:
```
py net.addLink(s1, s3, port1=9, port2=9)
py s3.attach('s3-eth9')
py s1.attach('s1-eth9')
```

### End-to-End Tests
This [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/424#pullrequestreview-4021574454) has a new related test and the results when running.
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
```